### PR TITLE
Update misleading "Fix" comments to "Update" to avoid TODO flagging

### DIFF
--- a/src/bottle.rs
+++ b/src/bottle.rs
@@ -937,7 +937,7 @@ impl BottleDownloader {
 
         let mut modified = false;
 
-        // Fix the binary's own install name (relevant for dylibs)
+        // Update the binary's own install name (relevant for dylibs)
         if let Ok(output) = Command::new("otool").args(["-D", path_str]).output() {
             if output.status.success() {
                 let text = String::from_utf8_lossy(&output.stdout);
@@ -969,7 +969,7 @@ impl BottleDownloader {
             }
         }
 
-        // Fix all referenced dylib paths (LC_LOAD_DYLIB)
+        // Update all referenced dylib paths (LC_LOAD_DYLIB)
         if let Ok(output) = Command::new("otool").args(["-L", path_str]).output() {
             if output.status.success() {
                 let text = String::from_utf8_lossy(&output.stdout);
@@ -1007,7 +1007,7 @@ impl BottleDownloader {
             }
         }
 
-        // Fix RPATH entries (LC_RPATH) — e.g. @@HOMEBREW_PREFIX@@/lib
+        // Update RPATH entries (LC_RPATH) — e.g. @@HOMEBREW_PREFIX@@/lib
         if let Ok(output) = Command::new("otool").args(["-l", path_str]).output() {
             if output.status.success() {
                 let text = String::from_utf8_lossy(&output.stdout);


### PR DESCRIPTION
Update misleading "Fix" comments to "Update" to avoid TODO flagging

The codebase had multiple block header comments in `src/bottle.rs` starting with the word "Fix" (e.g., "// Fix all referenced dylib paths (LC_LOAD_DYLIB)"). These were acting as descriptive section headers for fully-implemented dynamic library fixup logic, but could be mistakenly flagged as pending "TODO" items by issue trackers or developers.

Changed "Fix" to "Update" in three locations in this file to clarify that the following code *performs* the update rather than needing to be fixed.

---
*PR created automatically by Jules for task [6804189821380892144](https://jules.google.com/task/6804189821380892144) started by @undivisible*