### PR TITLE
🧹 Refactor audit command to improve readability

### DIFF
--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -5,6 +5,101 @@ use crate::version::is_same_or_newer;
 use console::style;
 use std::collections::HashMap;
 
+fn print_disabled(disabled: &[(&str, &str, &str)]) {
+    if disabled.is_empty() {
+        return;
+    }
+    println!(
+        "\n{} {} disabled {}:",
+        style("✗").red().bold(),
+        disabled.len(),
+        if disabled.len() == 1 {
+            "package"
+        } else {
+            "packages"
+        }
+    );
+    for (name, version, reason) in disabled {
+        println!(
+            "  {} {}  {}",
+            style(*name).red(),
+            style(format!("@{}", version)).dim(),
+            style(*reason).dim()
+        );
+    }
+}
+
+fn print_deprecated(deprecated: &[(&str, &str, &str)]) {
+    if deprecated.is_empty() {
+        return;
+    }
+    println!(
+        "\n{} {} deprecated {}:",
+        style("!").yellow().bold(),
+        deprecated.len(),
+        if deprecated.len() == 1 {
+            "package"
+        } else {
+            "packages"
+        }
+    );
+    for (name, version, reason) in deprecated {
+        println!(
+            "  {} {}  {}",
+            style(*name).yellow(),
+            style(format!("@{}", version)).dim(),
+            style(*reason).dim()
+        );
+    }
+}
+
+fn print_outdated(outdated: &[(&str, &str, String)]) {
+    if outdated.is_empty() {
+        return;
+    }
+    println!(
+        "\n{} {} outdated {}:",
+        style("↑").cyan().bold(),
+        outdated.len(),
+        if outdated.len() == 1 {
+            "package"
+        } else {
+            "packages"
+        }
+    );
+    for (name, installed_ver, latest_ver) in outdated {
+        println!(
+            "  {} {} → {}",
+            style(*name).cyan(),
+            style(*installed_ver).dim(),
+            style(latest_ver).green()
+        );
+    }
+}
+
+fn print_unknown(unknown: &[(&str, &str)]) {
+    if unknown.is_empty() {
+        return;
+    }
+    println!(
+        "\n{} {} {} not in any known tap:",
+        style("?").dim().bold(),
+        unknown.len(),
+        if unknown.len() == 1 {
+            "package"
+        } else {
+            "packages"
+        }
+    );
+    for (name, version) in unknown {
+        println!(
+            "  {} {}",
+            style(*name).dim(),
+            style(format!("@{}", version)).dim()
+        );
+    }
+}
+
 pub async fn audit(cache: &Cache) -> Result<()> {
     let state = InstallState::new()?;
     state.sync_from_cellar().await.ok();
@@ -63,88 +158,10 @@ pub async fn audit(cache: &Cache) -> Result<()> {
         return Ok(());
     }
 
-    if !disabled.is_empty() {
-        println!(
-            "\n{} {} disabled {}:",
-            style("✗").red().bold(),
-            disabled.len(),
-            if disabled.len() == 1 {
-                "package"
-            } else {
-                "packages"
-            }
-        );
-        for (name, version, reason) in &disabled {
-            println!(
-                "  {} {}  {}",
-                style(name).red(),
-                style(format!("@{}", version)).dim(),
-                style(reason).dim()
-            );
-        }
-    }
-
-    if !deprecated.is_empty() {
-        println!(
-            "\n{} {} deprecated {}:",
-            style("!").yellow().bold(),
-            deprecated.len(),
-            if deprecated.len() == 1 {
-                "package"
-            } else {
-                "packages"
-            }
-        );
-        for (name, version, reason) in &deprecated {
-            println!(
-                "  {} {}  {}",
-                style(name).yellow(),
-                style(format!("@{}", version)).dim(),
-                style(reason).dim()
-            );
-        }
-    }
-
-    if !outdated.is_empty() {
-        println!(
-            "\n{} {} outdated {}:",
-            style("↑").cyan().bold(),
-            outdated.len(),
-            if outdated.len() == 1 {
-                "package"
-            } else {
-                "packages"
-            }
-        );
-        for (name, installed_ver, latest_ver) in &outdated {
-            println!(
-                "  {} {} → {}",
-                style(name).cyan(),
-                style(installed_ver).dim(),
-                style(latest_ver).green()
-            );
-        }
-    }
-
-    if !unknown.is_empty() {
-        println!(
-            "\n{} {} {} not in any known tap:",
-            style("?").dim().bold(),
-            unknown.len(),
-            if unknown.len() == 1 {
-                "package"
-            } else {
-                "packages"
-            }
-        );
-        for (name, version) in &unknown {
-            println!(
-                "  {} {}",
-                style(name).dim(),
-                style(format!("@{}", version)).dim()
-            );
-        }
-    }
+    print_disabled(&disabled);
+    print_deprecated(&deprecated);
+    print_outdated(&outdated);
+    print_unknown(&unknown);
 
     println!("\n{} installed, {} issues", installed.len(), total_issues);
 


### PR DESCRIPTION
🎯 **What:** Extracted printing logic in `src/commands/audit.rs` into helper functions (`print_disabled`, `print_deprecated`, `print_outdated`, `print_unknown`).
💡 **Why:** The `audit` function was overly complex and long. Extracting the printing logic into smaller functions improves readability and maintainability.
✅ **Verification:** Verified by running `cargo fmt` and `cargo test` to ensure that no functionality is broken and code is formatted.
✨ **Result:** The `audit` function is now much cleaner and easier to read.

---
*PR created automatically by Jules for task [10561695923132892553](https://jules.google.com/task/10561695923132892553) started by @undivisible*