### PR TITLE
🧹 Refactor `info_cask` artifact mapping logic

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,5 +1,0 @@
-1. **Implement `as_str` on `CaskArtifact` in `src/api.rs`**: To avoid hardcoding long mapping of `CaskArtifact` enum variants to strings inside the command function, we'll create an `as_str` method on `CaskArtifact`.
-2. **Refactor `info_cask` in `src/commands/info.rs`**: Replace the overly complex mapping logic inside `info_cask` with `.map(|a| a.as_str())`. We'll also simplify the artifacts loop to iterate directly.
-3. **Verify Refactor**: Run `cargo check` and `cargo test` to ensure functionality remains the same and build passes.
-4. **Complete Pre-commit Steps**: Ensure `pre_commit_instructions` are followed (e.g., proper formatting, linting).
-5. **Submit**: Create PR.

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,5 @@
+1. **Implement `as_str` on `CaskArtifact` in `src/api.rs`**: To avoid hardcoding long mapping of `CaskArtifact` enum variants to strings inside the command function, we'll create an `as_str` method on `CaskArtifact`.
+2. **Refactor `info_cask` in `src/commands/info.rs`**: Replace the overly complex mapping logic inside `info_cask` with `.map(|a| a.as_str())`. We'll also simplify the artifacts loop to iterate directly.
+3. **Verify Refactor**: Run `cargo check` and `cargo test` to ensure functionality remains the same and build passes.
+4. **Complete Pre-commit Steps**: Ensure `pre_commit_instructions` are followed (e.g., proper formatting, linting).
+5. **Submit**: Create PR.

--- a/src/api.rs
+++ b/src/api.rs
@@ -169,6 +169,34 @@ pub enum CaskArtifact {
     Other(serde_json::Value),
 }
 
+impl CaskArtifact {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::App { .. } => "app",
+            Self::Pkg { .. } => "pkg",
+            Self::Binary { .. } => "binary",
+            Self::Font { .. } => "font",
+            Self::Manpage { .. } => "manpage",
+            Self::Dictionary { .. } => "dictionary",
+            Self::Colorpicker { .. } => "colorpicker",
+            Self::Prefpane { .. } => "prefpane",
+            Self::Qlplugin { .. } => "qlplugin",
+            Self::ScreenSaver { .. } => "screen_saver",
+            Self::Service { .. } => "service",
+            Self::Suite { .. } => "suite",
+            Self::Artifact { .. } => "artifact",
+            Self::BashCompletion { .. } => "bash_completion",
+            Self::ZshCompletion { .. } => "zsh_completion",
+            Self::FishCompletion { .. } => "fish_completion",
+            Self::Uninstall { .. } => "uninstall",
+            Self::Zap { .. } => "zap",
+            Self::Preflight { .. } => "preflight",
+            Self::Postflight { .. } => "postflight",
+            Self::Other(_) => "other",
+        }
+    }
+}
+
 impl Formula {
     pub fn full_version(&self) -> String {
         if self.revision > 0 {

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -220,31 +220,9 @@ async fn info_cask(cache: &Cache, name: &str) -> Result<()> {
     println!("{}", &cask.url);
 
     if let Some(artifacts) = &cask.artifacts {
-        let artifact_types: Vec<String> = artifacts
+        let artifact_types: Vec<&'static str> = artifacts
             .iter()
-            .map(|a| match a {
-                crate::api::CaskArtifact::App { .. } => "app".to_string(),
-                crate::api::CaskArtifact::Pkg { .. } => "pkg".to_string(),
-                crate::api::CaskArtifact::Binary { .. } => "binary".to_string(),
-                crate::api::CaskArtifact::Font { .. } => "font".to_string(),
-                crate::api::CaskArtifact::Manpage { .. } => "manpage".to_string(),
-                crate::api::CaskArtifact::Dictionary { .. } => "dictionary".to_string(),
-                crate::api::CaskArtifact::Colorpicker { .. } => "colorpicker".to_string(),
-                crate::api::CaskArtifact::Prefpane { .. } => "prefpane".to_string(),
-                crate::api::CaskArtifact::Qlplugin { .. } => "qlplugin".to_string(),
-                crate::api::CaskArtifact::ScreenSaver { .. } => "screen_saver".to_string(),
-                crate::api::CaskArtifact::Service { .. } => "service".to_string(),
-                crate::api::CaskArtifact::Suite { .. } => "suite".to_string(),
-                crate::api::CaskArtifact::Artifact { .. } => "artifact".to_string(),
-                crate::api::CaskArtifact::BashCompletion { .. } => "bash_completion".to_string(),
-                crate::api::CaskArtifact::ZshCompletion { .. } => "zsh_completion".to_string(),
-                crate::api::CaskArtifact::FishCompletion { .. } => "fish_completion".to_string(),
-                crate::api::CaskArtifact::Uninstall { .. } => "uninstall".to_string(),
-                crate::api::CaskArtifact::Zap { .. } => "zap".to_string(),
-                crate::api::CaskArtifact::Preflight { .. } => "preflight".to_string(),
-                crate::api::CaskArtifact::Postflight { .. } => "postflight".to_string(),
-                crate::api::CaskArtifact::Other(_) => "other".to_string(),
-            })
+            .map(|a| a.as_str())
             .collect();
 
         if !artifact_types.is_empty() {


### PR DESCRIPTION
🎯 **What:** Extracted the complex mapping of `CaskArtifact` variants to strings in `src/commands/info.rs` into a new `as_str` method on the `CaskArtifact` enum in `src/api.rs`.

💡 **Why:** The previous inline `match` statement in `info_cask` was overly long and complex, contributing to the function triggering the `clippy::cognitive_complexity` and `clippy::too_many_lines` lints. Moving this logic to the enum itself improves the readability and maintainability of the command module. It also replaces `String` allocations with `&'static str`, slightly improving performance.

✅ **Verification:** Verified via `cargo check` and `cargo test`. All checks passed, confirming no functionality was broken. A code review confirmed the safety and correctness of the change.

✨ **Result:** A cleaner, less complex `info_cask` function and a reusable string representation method for `CaskArtifact`s.

---
*PR created automatically by Jules for task [3727999051369292402](https://jules.google.com/task/3727999051369292402) started by @undivisible*