### PR TITLE
🧪 Add tests for `find_manifest` in `windows_state.rs`

### DIFF
--- a/src/windows_state.rs
+++ b/src/windows_state.rs
@@ -340,6 +340,71 @@ mod tests {
     }
 
     #[test]
+    fn find_manifest_resolves_and_filters() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::env::set_var("HOME", tmp.path());
+
+        let root = wax_windows_root().unwrap();
+
+        WindowsPackageManifest::new(
+            Ecosystem::Scoop,
+            "unique",
+            "1.0.0",
+            "https://example.invalid/unique.zip",
+            root.join("scoop-apps/unique/1.0.0"),
+            Vec::new(),
+            Vec::new(),
+        )
+        .save()
+        .unwrap();
+
+        WindowsPackageManifest::new(
+            Ecosystem::Scoop,
+            "duplicate",
+            "1.0.0",
+            "https://example.invalid/duplicate.zip",
+            root.join("scoop-apps/duplicate/1.0.0"),
+            Vec::new(),
+            Vec::new(),
+        )
+        .save()
+        .unwrap();
+
+        WindowsPackageManifest::new(
+            Ecosystem::Winget,
+            "duplicate",
+            "1.0.0",
+            "https://example.invalid/duplicate.zip",
+            root.join("winget-apps/duplicate/1.0.0"),
+            Vec::new(),
+            Vec::new(),
+        )
+        .save()
+        .unwrap();
+
+        // Ecosystem specified, should return unique match directly
+        let manifest = find_manifest("scoop/unique").unwrap().unwrap();
+        assert_eq!(manifest.id, "unique");
+        assert_eq!(manifest.ecosystem, Ecosystem::Scoop);
+
+        // No ecosystem, unique match
+        let manifest = find_manifest("unique").unwrap().unwrap();
+        assert_eq!(manifest.id, "unique");
+        assert_eq!(manifest.ecosystem, Ecosystem::Scoop);
+
+        // No ecosystem, ambiguous match
+        let err = find_manifest("duplicate").unwrap_err().to_string();
+        assert!(err.contains("multiple Windows packages match 'duplicate'"));
+        assert!(err.contains("scoop/duplicate"));
+        assert!(err.contains("winget/duplicate"));
+        assert!(err.contains("choco/duplicate"));
+
+        // No match
+        assert!(find_manifest("missing-tool").unwrap().is_none());
+    }
+
+    #[test]
     fn bin_link_collision_reports_existing_owner() {
         let _guard = ENV_LOCK.lock().unwrap();
         let tmp = tempfile::TempDir::new().unwrap();


### PR DESCRIPTION
🎯 **What:** The testing gap in `find_manifest` within `src/windows_state.rs` was addressed. Previously, the logic that parses package specs and searches through lists of manifests or falls back to exact loading lacked automated verification of its filtering and conflict detection behaviors.

📊 **Coverage:** The new test suite (`find_manifest_resolves_and_filters`) covers the following scenarios:
- **Explicit Ecosystem:** Finding a manifest directly via ecosystem prefix (e.g. `scoop/unique`).
- **Unique Fallback:** Filtering manifests when only the ID is provided and resolving to a single, unique match.
- **Ambiguous Fallback:** Ensuring an error is thrown mentioning the duplicate ecosystems when the same ID is matched across multiple ecosystems (e.g. Scoop and Winget).
- **Missing Match:** Verifying `None` is returned when the manifest ID is not found.

✨ **Result:** Improved test coverage for Windows manifest resolution scenarios, guaranteeing that package filtering and conflict detection works safely and regressions aren't inadvertently introduced.

---
*PR created automatically by Jules for task [13950710884074299616](https://jules.google.com/task/13950710884074299616) started by @undivisible*