### PR TITLE
🧹 Refactor upgrade_single to reduce complexity in upgrade command

### DIFF
--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -1018,6 +1018,16 @@ async fn upgrade_single(cache: &Cache, formula_name: &str, dry_run: bool) -> Res
         }
     };
 
+    upgrade_resolved_formula(cache, formula_name, installed_name, &installed, dry_run).await
+}
+
+async fn upgrade_resolved_formula(
+    cache: &Cache,
+    formula_name: &str,
+    installed_name: &str,
+    installed: &crate::install::InstalledPackage,
+    dry_run: bool,
+) -> Result<()> {
     if installed.pinned {
         println!(
             "{}@{} is pinned — skipping (run `wax unpin {}` to allow upgrades)",


### PR DESCRIPTION
🎯 **What:** Extracted the core execution logic of the `upgrade_single` function in `src/commands/upgrade.rs` into a new, separate asynchronous function named `upgrade_resolved_formula`.
💡 **Why:** `upgrade_single` was becoming overly complex and long, mixing the logic of determining package type (wax, cask, or formula) with the actual upgrade execution (pin checks, version comparisons, dry-runs). This refactoring separates concerns, improving readability and code health.
✅ **Verification:** Verified by compiling the project (`cargo check`), successfully running the full test suite (`cargo test`), and obtaining approval from the internal code review tool.
✨ **Result:** A more modular `upgrade_single` function that acts primarily as a dispatcher, and a dedicated `upgrade_resolved_formula` function that handles the intricacies of the upgrade itself.

---
*PR created automatically by Jules for task [11047570393415192428](https://jules.google.com/task/11047570393415192428) started by @undivisible*