### PR TITLE
🔒 Fix potential authentication token exposure by strictly enforcing HTTPS on HTTP clients

### DIFF
--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -15,7 +15,7 @@ fn user_agent() -> String {
 fn build_client(timeout: Duration, compress: bool) -> reqwest::Client {
     let mut builder = reqwest::Client::builder()
         .timeout(timeout)
-        .user_agent(user_agent());
+        .user_agent(user_agent()).https_only(true);
     if compress {
         builder = builder.gzip(true).brotli(true);
     } else {


### PR DESCRIPTION
🎯 **What:** Enforce HTTPS only in `reqwest::Client` builder within `src/http_client.rs`.

⚠️ **Risk:** The application could potentially fallback to unencrypted HTTP requests, which would expose sensitive authentication tokens (like GHCR tokens) in plain text over the network to interception, due to weak default configurations or environment variable overrides.

🛡️ **Solution:** Added `.https_only(true)` to the `reqwest::Client::builder()` configuration to strictly mandate HTTPS for all API, download, and default client requests originating from the application.

---
*PR created automatically by Jules for task [3130030704018541648](https://jules.google.com/task/3130030704018541648) started by @undivisible*