### PR TITLE
🧹 Refactor search command for complexity and readability

### DIFF
--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -18,237 +18,232 @@ use crate::remote_search::{
 pub async fn search(cache: &Cache, query: &str) -> Result<()> {
     #[cfg(target_os = "windows")]
     {
-        let (eco_filter, q) = crate::package_spec::parse_search_query(query);
-        crate::error::reject_brew_ecosystem(eco_filter)?;
-        let q = q.trim();
-        if q.is_empty() {
-            println!("empty search query");
-            return Ok(());
-        }
+        search_windows(cache, query).await
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        search_unix(cache, query).await
+    }
+}
 
-        let plan = windows_search_plan(eco_filter);
-        let remote_hits = if plan.include_scoop || plan.include_choco || plan.include_winget {
-            let hits = collect_remote_hits(
-                cache,
-                q,
-                plan.include_scoop,
-                plan.include_choco,
-                plan.include_winget,
-            )
-            .await?;
-            dedupe_remote_by_speed(hits)
-        } else {
-            Vec::new()
-        };
-
-        if remote_hits.is_empty() {
-            println!("no results for '{query}'");
-            return Ok(());
-        }
-
-        if let Some(eco) = eco_filter {
-            println!(
-                "{}",
-                style(format!(
-                    "Filtered to {} only (drop the prefix to search Scoop, winget, and Chocolatey)",
-                    eco.label()
-                ))
-                .dim()
-            );
-        }
-
-        let remote_section = match eco_filter {
-            Some(Ecosystem::Scoop) => "Scoop Main",
-            Some(Ecosystem::Winget) => "winget-pkgs",
-            Some(Ecosystem::Chocolatey) => "Chocolatey",
-            _ => "Windows catalogues (scoop, winget, choco)",
-        };
-        print_remote_hits(&remote_hits, remote_section);
-
+#[cfg(target_os = "windows")]
+async fn search_windows(cache: &Cache, query: &str) -> Result<()> {
+    let (eco_filter, q) = crate::package_spec::parse_search_query(query);
+    crate::error::reject_brew_ecosystem(eco_filter)?;
+    let q = q.trim();
+    if q.is_empty() {
+        println!("empty search query");
         return Ok(());
     }
 
-    #[cfg(not(target_os = "windows"))]
-    {
-        cache.ensure_fresh().await?;
+    let plan = windows_search_plan(eco_filter);
+    let remote_hits = if plan.include_scoop || plan.include_choco || plan.include_winget {
+        let hits = collect_remote_hits(
+            cache,
+            q,
+            plan.include_scoop,
+            plan.include_choco,
+            plan.include_winget,
+        )
+        .await?;
+        dedupe_remote_by_speed(hits)
+    } else {
+        Vec::new()
+    };
 
-        let formulae = cache.load_all_formulae().await?;
-        let casks = cache.load_casks().await?;
+    if remote_hits.is_empty() {
+        println!("no results for '{query}'");
+        return Ok(());
+    }
 
-        let state = InstallState::new()?;
-        let installed_packages = state.load().await?;
-        let cask_state = CaskState::new()?;
-        let installed_casks = cask_state.load().await?;
+    if let Some(eco) = eco_filter {
+        println!(
+            "{}",
+            style(format!(
+                "Filtered to {} only (drop the prefix to search Scoop, winget, and Chocolatey)",
+                eco.label()
+            ))
+            .dim()
+        );
+    }
 
-        let core_formulae: Vec<_> = formulae
-            .iter()
-            .filter(|f| !f.full_name.contains('/') || f.full_name.starts_with("homebrew/"))
-            .collect();
+    let remote_section = match eco_filter {
+        Some(Ecosystem::Scoop) => "Scoop Main",
+        Some(Ecosystem::Winget) => "winget-pkgs",
+        Some(Ecosystem::Chocolatey) => "Chocolatey",
+        _ => "Windows catalogues (scoop, winget, choco)",
+    };
+    print_remote_hits(&remote_hits, remote_section);
 
-        let tap_formulae: Vec<_> = formulae
-            .iter()
-            .filter(|f| f.full_name.contains('/') && !f.full_name.starts_with("homebrew/"))
-            .collect();
+    Ok(())
+}
 
-        let mut formula_matches: Vec<_> = core_formulae
-            .iter()
-            .filter_map(|f| {
-                crate::catalog_match::match_score(&f.name, f.desc.as_deref(), query)
-                    .map(|score| (f, score))
-            })
-            .collect();
+#[cfg(not(target_os = "windows"))]
+async fn search_unix(cache: &Cache, query: &str) -> Result<()> {
+    cache.ensure_fresh().await?;
 
-        let mut tap_matches: Vec<_> = tap_formulae
-            .iter()
-            .filter_map(|f| {
-                let name_score =
-                    crate::catalog_match::match_score(&f.name, f.desc.as_deref(), query);
-                let full_name_score =
-                    crate::catalog_match::match_score(&f.full_name, f.desc.as_deref(), query);
-                name_score.or(full_name_score).map(|score| (f, score))
-            })
-            .collect();
+    let formulae = cache.load_all_formulae().await?;
+    let casks = cache.load_casks().await?;
 
-        let mut cask_matches: Vec<_> = casks
-            .iter()
-            .filter_map(|c| {
-                let token_score =
-                    crate::catalog_match::match_score(&c.token, c.desc.as_deref(), query);
-                let name_score = c
-                    .name
-                    .iter()
-                    .filter_map(|n| crate::catalog_match::match_score(n, c.desc.as_deref(), query))
-                    .max();
-                token_score.or(name_score).map(|score| (c, score))
-            })
-            .collect();
+    let state = InstallState::new()?;
+    let installed_packages = state.load().await?;
+    let cask_state = CaskState::new()?;
+    let installed_casks = cask_state.load().await?;
 
-        formula_matches.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.name.cmp(&b.0.name)));
-        tap_matches.sort_by(|a, b| {
-            b.1.cmp(&a.1)
-                .then_with(|| a.0.full_name.cmp(&b.0.full_name))
-        });
-        cask_matches.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.token.cmp(&b.0.token)));
+    let core_formulae: Vec<_> = formulae
+        .iter()
+        .filter(|f| !f.full_name.contains('/') || f.full_name.starts_with("homebrew/"))
+        .collect();
 
-        let formula_matches: Vec<_> = formula_matches.iter().take(20).map(|(f, _)| f).collect();
-        let tap_matches: Vec<_> = tap_matches.iter().take(10).map(|(f, _)| f).collect();
-        let cask_matches: Vec<_> = cask_matches.iter().take(20).map(|(c, _)| c).collect();
+    let tap_formulae: Vec<_> = formulae
+        .iter()
+        .filter(|f| f.full_name.contains('/') && !f.full_name.starts_with("homebrew/"))
+        .collect();
 
-        let total = formula_matches.len() + tap_matches.len() + cask_matches.len();
+    let mut formula_matches: Vec<_> = core_formulae
+        .iter()
+        .filter_map(|f| {
+            crate::catalog_match::match_score(&f.name, f.desc.as_deref(), query)
+                .map(|score| (f, score))
+        })
+        .collect();
 
-        if total == 0 {
-            println!("no results for '{}'", query);
-            return Ok(());
-        }
+    let mut tap_matches: Vec<_> = tap_formulae
+        .iter()
+        .filter_map(|f| {
+            let name_score = crate::catalog_match::match_score(&f.name, f.desc.as_deref(), query);
+            let full_name_score =
+                crate::catalog_match::match_score(&f.full_name, f.desc.as_deref(), query);
+            name_score.or(full_name_score).map(|score| (f, score))
+        })
+        .collect();
 
-        println!();
-        for formula in &formula_matches {
-            let desc = formula.desc.as_deref().unwrap_or("");
-            let installed_suffix = if installed_packages.contains_key(&formula.name) {
-                " · installed"
+    let mut cask_matches: Vec<_> = casks
+        .iter()
+        .filter_map(|c| {
+            let token_score = crate::catalog_match::match_score(&c.token, c.desc.as_deref(), query);
+            let name_score = c
+                .name
+                .iter()
+                .filter_map(|n| crate::catalog_match::match_score(n, c.desc.as_deref(), query))
+                .max();
+            token_score.or(name_score).map(|score| (c, score))
+        })
+        .collect();
+
+    formula_matches.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.name.cmp(&b.0.name)));
+    tap_matches.sort_by(|a, b| {
+        b.1.cmp(&a.1)
+            .then_with(|| a.0.full_name.cmp(&b.0.full_name))
+    });
+    cask_matches.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.token.cmp(&b.0.token)));
+
+    let formula_matches: Vec<_> = formula_matches.iter().take(20).map(|(f, _)| f).collect();
+    let tap_matches: Vec<_> = tap_matches.iter().take(10).map(|(f, _)| f).collect();
+    let cask_matches: Vec<_> = cask_matches.iter().take(20).map(|(c, _)| c).collect();
+
+    let total = formula_matches.len() + tap_matches.len() + cask_matches.len();
+
+    if total == 0 {
+        println!("no results for '{}'", query);
+        return Ok(());
+    }
+
+    println!();
+    for formula in &formula_matches {
+        print_formula(
+            formula,
+            installed_packages.contains_key(&formula.name),
+            &formula.name,
+        );
+    }
+
+    for formula in &tap_matches {
+        print_formula(
+            formula,
+            installed_packages.contains_key(&formula.name),
+            &formula.full_name,
+        );
+    }
+
+    for cask in &cask_matches {
+        print_cask(cask, installed_casks.contains_key(&cask.token));
+    }
+
+    let mut parts = Vec::new();
+    if !formula_matches.is_empty() {
+        parts.push(format!(
+            "{} {}",
+            formula_matches.len(),
+            if formula_matches.len() == 1 {
+                "formula"
             } else {
-                ""
-            };
-            let status_label = if formula.disabled {
-                format!(" {}", style("[disabled]").red())
-            } else if formula.deprecated {
-                format!(" {}", style("[deprecated]").yellow())
-            } else {
-                String::new()
-            };
-            println!(
-                "{} · {}{}{}",
-                style(&formula.name).magenta(),
-                style(&formula.versions.stable).dim(),
-                style(installed_suffix).dim(),
-                status_label
-            );
-            if !desc.is_empty() {
-                println!("  {}", desc);
+                "formulae"
             }
-        }
-
-        for formula in &tap_matches {
-            let desc = formula.desc.as_deref().unwrap_or("");
-            let installed_suffix = if installed_packages.contains_key(&formula.name) {
-                " · installed"
+        ));
+    }
+    if !tap_matches.is_empty() {
+        parts.push(format!("{} from taps", tap_matches.len()));
+    }
+    if !cask_matches.is_empty() {
+        parts.push(format!(
+            "{} {}",
+            cask_matches.len(),
+            if cask_matches.len() == 1 {
+                "cask"
             } else {
-                ""
-            };
-            let status_label = if formula.disabled {
-                format!(" {}", style("[disabled]").red())
-            } else if formula.deprecated {
-                format!(" {}", style("[deprecated]").yellow())
-            } else {
-                String::new()
-            };
-            println!(
-                "{} · {}{}{}",
-                style(&formula.full_name).magenta(),
-                style(&formula.versions.stable).dim(),
-                style(installed_suffix).dim(),
-                status_label
-            );
-            if !desc.is_empty() {
-                println!("  {}", desc);
+                "casks"
             }
-        }
+        ));
+    }
+    println!("\n{}", style(parts.join(", ")).dim());
 
-        for cask in &cask_matches {
-            let desc = cask.desc.as_deref().unwrap_or("");
-            let installed_suffix = if installed_casks.contains_key(&cask.token) {
-                " · installed"
-            } else {
-                ""
-            };
-            let status_label = if cask.disabled {
-                format!(" {}", style("[disabled]").red())
-            } else if cask.deprecated {
-                format!(" {}", style("[deprecated]").yellow())
-            } else {
-                String::new()
-            };
-            println!(
-                "{} {} · {}{}{}",
-                style(&cask.token).magenta(),
-                style("(cask)").yellow(),
-                style(&cask.version).dim(),
-                style(installed_suffix).dim(),
-                status_label
-            );
-            if !desc.is_empty() {
-                println!("  {}", desc);
-            }
-        }
+    Ok(())
+}
 
-        let mut parts = Vec::new();
-        if !formula_matches.is_empty() {
-            parts.push(format!(
-                "{} {}",
-                formula_matches.len(),
-                if formula_matches.len() == 1 {
-                    "formula"
-                } else {
-                    "formulae"
-                }
-            ));
-        }
-        if !tap_matches.is_empty() {
-            parts.push(format!("{} from taps", tap_matches.len()));
-        }
-        if !cask_matches.is_empty() {
-            parts.push(format!(
-                "{} {}",
-                cask_matches.len(),
-                if cask_matches.len() == 1 {
-                    "cask"
-                } else {
-                    "casks"
-                }
-            ));
-        }
-        println!("\n{}", style(parts.join(", ")).dim());
+#[cfg(not(target_os = "windows"))]
+fn print_formula(formula: &crate::api::Formula, is_installed: bool, display_name: &str) {
+    let desc = formula.desc.as_deref().unwrap_or("");
+    let installed_suffix = if is_installed { " · installed" } else { "" };
+    let status_label = if formula.disabled {
+        format!(" {}", style("[disabled]").red())
+    } else if formula.deprecated {
+        format!(" {}", style("[deprecated]").yellow())
+    } else {
+        String::new()
+    };
+    println!(
+        "{} · {}{}{}",
+        style(display_name).magenta(),
+        style(&formula.versions.stable).dim(),
+        style(installed_suffix).dim(),
+        status_label
+    );
+    if !desc.is_empty() {
+        println!("  {}", desc);
+    }
+}
 
-        Ok(())
+#[cfg(not(target_os = "windows"))]
+fn print_cask(cask: &crate::api::Cask, is_installed: bool) {
+    let desc = cask.desc.as_deref().unwrap_or("");
+    let installed_suffix = if is_installed { " · installed" } else { "" };
+    let status_label = if cask.disabled {
+        format!(" {}", style("[disabled]").red())
+    } else if cask.deprecated {
+        format!(" {}", style("[deprecated]").yellow())
+    } else {
+        String::new()
+    };
+    println!(
+        "{} {} · {}{}{}",
+        style(&cask.token).magenta(),
+        style("(cask)").yellow(),
+        style(&cask.version).dim(),
+        style(installed_suffix).dim(),
+        status_label
+    );
+    if !desc.is_empty() {
+        println!("  {}", desc);
     }
 }


### PR DESCRIPTION
🎯 **What:** Extracted OS-specific search logic (`search_windows`, `search_unix`) from `search` and created printing helpers (`print_formula`, `print_cask`).
💡 **Why:** The `search` function was overly complex due to large `#[cfg]` blocks and repetitive iteration logic for matching formulas and casks. These extractions decrease complexity and increase readability.
✅ **Verification:** Verified that the implementation is syntactically correct and tests passed through `cargo check`, `cargo fmt`, `cargo clippy`, and `cargo test`.
✨ **Result:** Improved modularity and readability of `src/commands/search.rs` while keeping the exact functionality.

---
*PR created automatically by Jules for task [3441424316576438260](https://jules.google.com/task/3441424316576438260) started by @undivisible*