### PR TITLE
🧹 chore: update misleading comments in bottle.rs to prevent false TODO flags

### DIFF
--- a/src/bottle.rs
+++ b/src/bottle.rs
@@ -937,7 +937,7 @@ impl BottleDownloader {
 
         let mut modified = false;
 
-        // Fix the binary's own install name (relevant for dylibs)
+        // Relocate the binary's own install name (relevant for dylibs)
         if let Ok(output) = Command::new("otool").args(["-D", path_str]).output() {
             if output.status.success() {
                 let text = String::from_utf8_lossy(&output.stdout);
@@ -969,7 +969,7 @@ impl BottleDownloader {
             }
         }
 
-        // Fix all referenced dylib paths (LC_LOAD_DYLIB)
+        // Relocate all referenced dylib paths (LC_LOAD_DYLIB)
         if let Ok(output) = Command::new("otool").args(["-L", path_str]).output() {
             if output.status.success() {
                 let text = String::from_utf8_lossy(&output.stdout);
@@ -1007,7 +1007,7 @@ impl BottleDownloader {
             }
         }
 
-        // Fix RPATH entries (LC_RPATH) — e.g. @@HOMEBREW_PREFIX@@/lib
+        // Relocate RPATH entries (LC_RPATH) — e.g. @@HOMEBREW_PREFIX@@/lib
         if let Ok(output) = Command::new("otool").args(["-l", path_str]).output() {
             if output.status.success() {
                 let text = String::from_utf8_lossy(&output.stdout);


### PR DESCRIPTION
🧹 Update misleading comments in `src/bottle.rs`

🎯 What
Renamed the `// Fix ` prefix in three comments in `src/bottle.rs` to `// Relocate ` to more accurately describe the existing implementation immediately following them.

💡 Why
Comments starting with "Fix" can be incorrectly flagged by automated TODO/issue trackers as missing implementations or pending tasks.

✅ Verification
Ran `cargo test` and verified the comments update locally. The code logic has not been altered.

✨ Result
Cleaner codebase with comments that accurately reflect the state of the code.

---
*PR created automatically by Jules for task [16962389424420679381](https://jules.google.com/task/16962389424420679381) started by @undivisible*