### PR TITLE
🔒 Fix potential command injection in run_command_with_timeout

### DIFF
--- a/src/bottle.rs
+++ b/src/bottle.rs
@@ -1271,9 +1271,24 @@ impl Default for BottleDownloader {
     }
 }
 
-pub fn run_command_with_timeout(cmd: &str, args: &[&str], timeout_secs: u64) -> Option<String> {
+#[allow(dead_code)]
+pub enum SafeCommand {
+    Brew,
+    SwVers,
+}
+
+impl SafeCommand {
+    fn as_str(&self) -> &'static str {
+        match self {
+            SafeCommand::Brew => "brew",
+            SafeCommand::SwVers => "sw_vers",
+        }
+    }
+}
+
+pub fn run_command_with_timeout(cmd: SafeCommand, args: &[&str], timeout_secs: u64) -> Option<String> {
     let (tx, rx) = mpsc::channel();
-    let cmd_str = cmd.to_string();
+    let cmd_str = cmd.as_str().to_string();
     let args_vec: Vec<String> = args.iter().map(|s| s.to_string()).collect();
 
     thread::spawn(move || {
@@ -1330,7 +1345,7 @@ fn macos_codename() -> &'static str {
 fn macos_version() -> String {
     #[cfg(target_os = "macos")]
     {
-        if let Some(version) = run_command_with_timeout("sw_vers", &["-productVersion"], 1) {
+        if let Some(version) = run_command_with_timeout(SafeCommand::SwVers, &["-productVersion"], 1) {
             if let Some(major) = version.split('.').next() {
                 return major.to_string();
             }
@@ -1370,7 +1385,7 @@ pub fn homebrew_prefix() -> PathBuf {
         _ => PathBuf::from("/usr/local"),
     };
 
-    if let Some(prefix_str) = run_command_with_timeout("brew", &["--prefix"], 2) {
+    if let Some(prefix_str) = run_command_with_timeout(SafeCommand::Brew, &["--prefix"], 2) {
         let brew_prefix = PathBuf::from(&prefix_str);
         if brew_prefix.join("Cellar").exists() {
             if brew_prefix != standard_prefix {

--- a/src/install.rs
+++ b/src/install.rs
@@ -1,4 +1,4 @@
-use crate::bottle::{detect_platform, homebrew_prefix, run_command_with_timeout};
+use crate::bottle::{detect_platform, homebrew_prefix, run_command_with_timeout, SafeCommand};
 use crate::error::{Result, WaxError};
 use crate::sudo;
 use crate::ui::dirs;
@@ -226,7 +226,7 @@ impl InstallState {
         let arch = std::env::consts::ARCH;
 
         let mut candidates =
-            if let Some(prefix_str) = run_command_with_timeout("brew", &["--prefix"], 2) {
+            if let Some(prefix_str) = run_command_with_timeout(SafeCommand::Brew, &["--prefix"], 2) {
                 vec![PathBuf::from(prefix_str.trim())]
             } else {
                 match os {


### PR DESCRIPTION
🎯 **What:** Fixed a potential command injection vulnerability in `run_command_with_timeout` inside `src/bottle.rs`.
⚠️ **Risk:** The previous implementation took a generic string for the command, making it theoretically possible for untrusted inputs to execute arbitrary binaries.
🛡️ **Solution:** Replaced the generic `&str` command parameter with a strongly typed `SafeCommand` enum containing only whitelisted options (`Brew`, `SwVers`). This makes arbitrary command injection mathematically impossible at compile time, resolving the vulnerability effectively.

---
*PR created automatically by Jules for task [14527882864138364871](https://jules.google.com/task/14527882864138364871) started by @undivisible*