### PR TITLE
🧪 Add missing branch tests for windows_search_plan

### DIFF
--- a/src/remote_search.rs
+++ b/src/remote_search.rs
@@ -520,6 +520,30 @@ mod tests {
     }
 
     #[test]
+    fn windows_scoop_prefix_search_matches_scoop_only() {
+        let plan = windows_search_plan(Some(Ecosystem::Scoop));
+        assert!(plan.include_scoop);
+        assert!(!plan.include_choco);
+        assert!(!plan.include_winget);
+    }
+
+    #[test]
+    fn windows_winget_prefix_search_matches_winget_only() {
+        let plan = windows_search_plan(Some(Ecosystem::Winget));
+        assert!(!plan.include_scoop);
+        assert!(!plan.include_choco);
+        assert!(plan.include_winget);
+    }
+
+    #[test]
+    fn windows_choco_prefix_search_matches_choco_only() {
+        let plan = windows_search_plan(Some(Ecosystem::Chocolatey));
+        assert!(!plan.include_scoop);
+        assert!(plan.include_choco);
+        assert!(!plan.include_winget);
+    }
+
+    #[test]
     fn scoop_tree_path_parses_bucket_json() {
         assert_eq!(
             scoop_name_from_tree_path("bucket/ripgrep.json").as_deref(),


### PR DESCRIPTION
🎯 **What:** Added tests for the remaining branches in `windows_search_plan`.
📊 **Coverage:** Covered cases for `Ecosystem::Scoop`, `Ecosystem::Winget`, and `Ecosystem::Chocolatey`.
✨ **Result:** Now all branches of `windows_search_plan` are tested and covered.

---
*PR created automatically by Jules for task [1507884223483011371](https://jules.google.com/task/1507884223483011371) started by @undivisible*