### PR TITLE
🔒 Prevent command injection in source command

### DIFF
--- a/src/commands/source.rs
+++ b/src/commands/source.rs
@@ -4,6 +4,14 @@ use console::style;
 use std::collections::HashMap;
 use tracing::instrument;
 fn is_safe_url(url_str: &str) -> bool {
+    // Prevent command injection via shell metacharacters
+    let dangerous_chars = [
+        '`', '$', ';', '|', '<', '>', '"', '\'', '\\', '{', '}', '\n', '\r', '\t', ' ',
+    ];
+    if url_str.contains(dangerous_chars) {
+        return false;
+    }
+
     if let Ok(url) = reqwest::Url::parse(url_str) {
         matches!(url.scheme(), "http" | "https")
     } else {
@@ -101,5 +109,13 @@ mod tests {
         assert!(!is_safe_url("-a Terminal"));
         assert!(!is_safe_url("/usr/bin/local"));
         assert!(!is_safe_url("example.com")); // Missing scheme
+
+        // Command injection payloads
+        assert!(!is_safe_url("http://example.com;rm -rf /"));
+        assert!(!is_safe_url("http://example.com/$(whoami)"));
+        assert!(!is_safe_url("http://example.com/`whoami`"));
+        assert!(!is_safe_url("http://example.com' --no-sandbox"));
+        assert!(!is_safe_url("http://example.com\" --no-sandbox"));
+        assert!(!is_safe_url("http://example.com|whoami"));
     }
 }


### PR DESCRIPTION
🎯 **What:** The `source` command was vulnerable to command injection because the `is_safe_url` function only verified the URL scheme without checking for shell metacharacters. 

⚠️ **Risk:** An attacker could craft a malicious URL containing shell metacharacters (like `;`, `$`, `` ` ``, `|`, etc.) in a formula or cask's homepage. When a user runs the `source` command for that package, `std::process::Command::new` passing it to `xdg-open` (or `open`) could result in arbitrary command execution on the user's system, since tools like `xdg-open` are sometimes implemented as shell scripts that improperly quote arguments or evaluate them unsafely.

🛡️ **Solution:** Updated `is_safe_url` in `src/commands/source.rs` to validate URLs against a comprehensive blocklist of dangerous shell metacharacters (including spaces, quotes, pipes, redirection operators, and command substitution syntax) before allowing them to be opened. Added multiple test cases to verify that command injection payloads are rejected.

---
*PR created automatically by Jules for task [11745519963173084929](https://jules.google.com/task/11745519963173084929) started by @undivisible*