### PR TITLE
🧪 [Testing improvement for homebrew_user_agent]

### DIFF
--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -51,3 +51,23 @@ pub fn download() -> &'static reqwest::Client {
 pub fn default_client() -> &'static reqwest::Client {
     DEFAULT_CLIENT.get_or_init(|| build_client(Duration::from_secs(60), true))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_homebrew_user_agent() {
+        let ua = homebrew_user_agent();
+        assert!(ua.starts_with("Homebrew/"));
+        assert!(ua.contains(" (Macintosh; "));
+        assert!(ua.ends_with(" Mac OS X)"));
+
+        let arch = if cfg!(target_arch = "aarch64") {
+            "arm64"
+        } else {
+            "x86_64"
+        };
+        assert!(ua.contains(arch));
+    }
+}


### PR DESCRIPTION
🎯 **What:** The `homebrew_user_agent` function in `src/http_client.rs` lacked test coverage, despite containing conditional logic based on the target architecture.
📊 **Coverage:** A new test has been added to verify that the generated User-Agent string is correctly formatted (starts with "Homebrew/", ends with " Mac OS X)", and has the Macintosh identifier). It also covers the `target_arch` conditional logic, ensuring that either 'arm64' or 'x86_64' is embedded in the result depending on the compilation target.
✨ **Result:** Test coverage for `homebrew_user_agent` is successfully established, helping to catch any future regressions in User-Agent formatting.

---
*PR created automatically by Jules for task [5069026295782429287](https://jules.google.com/task/5069026295782429287) started by @undivisible*