### PR TITLE
🔒 Fix git clone argument injection vulnerabilities

### DIFF
--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -573,7 +573,7 @@ async fn install_from_head_task(
     spinner.set_message(format!("Cloning HEAD from {}...", head_url));
 
     let clone_output = tokio::process::Command::new("git")
-        .args(["clone", "--depth=1", head_url])
+        .args(["clone", "--depth=1", "--", head_url])
         .arg(&clone_dir)
         .output()
         .await?;

--- a/src/tap.rs
+++ b/src/tap.rs
@@ -345,6 +345,7 @@ impl TapManager {
             .arg("clone")
             .arg("--depth=1")
             .arg("--single-branch")
+            .arg("--")
             .arg(&url)
             .arg(&tap.path)
             .output()


### PR DESCRIPTION
🎯 **What:** 
Fixed a vulnerability where untrusted URLs passed to `git clone` could be interpreted as command-line arguments (e.g., `--upload-pack=...`), leading to argument injection attacks. This issue was found in `src/commands/install.rs` (cloning HEAD formula sources) and `src/tap.rs` (cloning third-party taps).

⚠️ **Risk:** 
If an attacker can trick the user into installing a malicious formula or adding a malicious tap with a specially crafted URL, they could execute arbitrary code or write files outside the intended directories during the `git clone` process.

🛡️ **Solution:** 
Added the `--` argument separator right before the URL argument in `tokio::process::Command::new("git").args(...)` calls. This guarantees that `git` strictly treats the URL as a positional argument and never parses it as an option or flag, effectively neutralizing the injection vector.

---
*PR created automatically by Jules for task [13206691364463930531](https://jules.google.com/task/13206691364463930531) started by @undivisible*