### PR TITLE
🔒 Fix Argument Injection in System Package Manager Execution

### DIFF
--- a/src/system_pm.rs
+++ b/src/system_pm.rs
@@ -125,47 +125,47 @@ impl SystemPm {
 
         match self {
             Self::Apt => {
-                let mut args = vec!["apt-get", "install", "-y"];
+                let mut args = vec!["apt-get", "install", "-y", "--"];
                 args.extend_from_slice(&pkg_args);
                 run_visible("sudo", &args).await?;
             }
             Self::Dnf => {
-                let mut args = vec!["dnf", "install", "-y"];
+                let mut args = vec!["dnf", "install", "-y", "--"];
                 args.extend_from_slice(&pkg_args);
                 run_visible("sudo", &args).await?;
             }
             Self::Pacman => {
-                let mut args = vec!["pacman", "-S", "--noconfirm"];
+                let mut args = vec!["pacman", "-S", "--noconfirm", "--"];
                 args.extend_from_slice(&pkg_args);
                 run_visible("sudo", &args).await?;
             }
             Self::Apk => {
-                let mut args = vec!["apk", "add"];
+                let mut args = vec!["apk", "add", "--"];
                 args.extend_from_slice(&pkg_args);
                 run_visible("sudo", &args).await?;
             }
             Self::Zypper => {
-                let mut args = vec!["zypper", "install", "-y"];
+                let mut args = vec!["zypper", "install", "-y", "--"];
                 args.extend_from_slice(&pkg_args);
                 run_visible("sudo", &args).await?;
             }
             Self::Emerge => {
-                let mut args: Vec<&str> = vec!["emerge"];
+                let mut args: Vec<&str> = vec!["emerge", "--"];
                 args.extend_from_slice(&pkg_args);
                 run_visible("sudo", &args).await?;
             }
             Self::Yum => {
-                let mut args = vec!["yum", "install", "-y"];
+                let mut args = vec!["yum", "install", "-y", "--"];
                 args.extend_from_slice(&pkg_args);
                 run_visible("sudo", &args).await?;
             }
             Self::Xbps => {
-                let mut args = vec!["xbps-install", "-S"];
+                let mut args = vec!["xbps-install", "-S", "--"];
                 args.extend_from_slice(&pkg_args);
                 run_visible("sudo", &args).await?;
             }
             Self::Nix => {
-                let mut args = vec!["-i"];
+                let mut args = vec!["-i", "--"];
                 args.extend_from_slice(&pkg_args);
                 run_visible("nix-env", &args).await?;
             }


### PR DESCRIPTION
🎯 **What:** The `SystemPm::install` function was passing dynamic package names directly to system package managers (`apt-get`, `dnf`, `pacman`, etc.) without an end-of-options marker (`--`).
⚠️ **Risk:** If a malicious or malformed package name started with a hyphen (`-`), the package manager could interpret it as a command-line option rather than a package name. This could lead to argument injection vulnerabilities, potentially allowing for arbitrary code execution with root privileges (as these commands are often run with `sudo`).
🛡️ **Solution:** Added the end-of-options marker (`"--"`) before extending the package arguments for all system package managers in `src/system_pm.rs`. This ensures that any subsequent arguments are strictly treated as package names, mitigating the injection risk.

---
*PR created automatically by Jules for task [247726296469878946](https://jules.google.com/task/247726296469878946) started by @undivisible*