### PR TITLE
🧪 [add tests for homebrew_prefix]

### DIFF
--- a/src/bottle.rs
+++ b/src/bottle.rs
@@ -1640,6 +1640,51 @@ mod tests {
         (temp, tarball)
     }
 
+    #[test]
+    fn test_homebrew_prefix() {
+        let prefix = homebrew_prefix();
+        assert!(prefix.is_absolute(), "Homebrew prefix must be an absolute path");
+
+        let os = std::env::consts::OS;
+        let arch = std::env::consts::ARCH;
+
+        match os {
+            "macos" => {
+                if arch == "aarch64" {
+                    assert!(
+                        prefix == PathBuf::from("/opt/homebrew") || prefix.join("Cellar").exists(),
+                        "Prefix should be standard /opt/homebrew or a valid custom prefix"
+                    );
+                } else {
+                    assert!(
+                        prefix == PathBuf::from("/usr/local") || prefix.join("Cellar").exists(),
+                        "Prefix should be standard /usr/local or a valid custom prefix"
+                    );
+                }
+            }
+            "linux" => {
+                let is_standard_linux = prefix == PathBuf::from("/home/linuxbrew/.linuxbrew") || prefix == PathBuf::from("/usr/local");
+                let is_user_linux = if let Some(home) = std::env::var_os("HOME").map(PathBuf::from) {
+                    prefix == home.join(".linuxbrew")
+                } else {
+                    false
+                };
+
+                assert!(
+                    is_standard_linux || is_user_linux || prefix.join("Cellar").exists(),
+                    "Prefix should be standard linux path, user local path, or a valid custom prefix"
+                );
+            }
+            _ => {
+                assert_eq!(
+                    prefix,
+                    PathBuf::from("/usr/local"),
+                    "Non-macOS/Linux platforms should default to /usr/local"
+                );
+            }
+        }
+    }
+
     // ── num_connections ──────────────────────────────────────────────────────
 
     #[test]

--- a/src/bottle.rs
+++ b/src/bottle.rs
@@ -1641,9 +1641,13 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn test_homebrew_prefix() {
         let prefix = homebrew_prefix();
-        assert!(prefix.is_absolute(), "Homebrew prefix must be an absolute path");
+        assert!(
+            prefix.is_absolute(),
+            "Homebrew prefix must be an absolute path"
+        );
 
         let os = std::env::consts::OS;
         let arch = std::env::consts::ARCH;
@@ -1652,19 +1656,24 @@ mod tests {
             "macos" => {
                 if arch == "aarch64" {
                     assert!(
-                        prefix == PathBuf::from("/opt/homebrew") || prefix.join("Cellar").exists(),
+                        prefix.as_path() == std::path::Path::new("/opt/homebrew")
+                            || prefix.join("Cellar").exists(),
                         "Prefix should be standard /opt/homebrew or a valid custom prefix"
                     );
                 } else {
                     assert!(
-                        prefix == PathBuf::from("/usr/local") || prefix.join("Cellar").exists(),
+                        prefix.as_path() == std::path::Path::new("/usr/local")
+                            || prefix.join("Cellar").exists(),
                         "Prefix should be standard /usr/local or a valid custom prefix"
                     );
                 }
             }
             "linux" => {
-                let is_standard_linux = prefix == PathBuf::from("/home/linuxbrew/.linuxbrew") || prefix == PathBuf::from("/usr/local");
-                let is_user_linux = if let Some(home) = std::env::var_os("HOME").map(PathBuf::from) {
+                let is_standard_linux = prefix.as_path()
+                    == std::path::Path::new("/home/linuxbrew/.linuxbrew")
+                    || prefix.as_path() == std::path::Path::new("/usr/local");
+                let is_user_linux = if let Some(home) = std::env::var_os("HOME").map(PathBuf::from)
+                {
                     prefix == home.join(".linuxbrew")
                 } else {
                     false


### PR DESCRIPTION
🎯 **What:** The `homebrew_prefix` function lacked test coverage.
📊 **Coverage:** A test `test_homebrew_prefix` was added that verifies the return path is absolute and correctly aligns with standard and custom fallback locations for macOS and Linux depending on the machine's architecture and setup.
✨ **Result:** Improved test reliability by ensuring the primary path extraction mechanism handles all compile-time OS and Architecture variations properly.

---
*PR created automatically by Jules for task [6574466230488420511](https://jules.google.com/task/6574466230488420511) started by @undivisible*