### PR TITLE
🧹 [Extract search logic and formatting]

### DIFF
--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -79,17 +79,18 @@ async fn search_windows(cache: &Cache, query: &str) -> Result<()> {
 }
 
 #[cfg(not(target_os = "windows"))]
-async fn search_unix(cache: &Cache, query: &str) -> Result<()> {
-    cache.ensure_fresh().await?;
+struct UnixSearchResults<'a> {
+    formula_matches: Vec<&'a crate::api::Formula>,
+    tap_matches: Vec<&'a crate::api::Formula>,
+    cask_matches: Vec<&'a crate::api::Cask>,
+}
 
-    let formulae = cache.load_all_formulae().await?;
-    let casks = cache.load_all_casks().await?;
-
-    let state = InstallState::new()?;
-    let installed_packages = state.load().await?;
-    let cask_state = CaskState::new()?;
-    let installed_casks = cask_state.load().await?;
-
+#[cfg(not(target_os = "windows"))]
+fn find_unix_matches<'a>(
+    formulae: &'a [crate::api::Formula],
+    casks: &'a [crate::api::Cask],
+    query: &str,
+) -> UnixSearchResults<'a> {
     let core_formulae: Vec<_> = formulae
         .iter()
         .filter(|f| !f.full_name.contains('/') || f.full_name.starts_with("homebrew/"))
@@ -104,7 +105,7 @@ async fn search_unix(cache: &Cache, query: &str) -> Result<()> {
         .iter()
         .filter_map(|f| {
             crate::catalog_match::match_score(&f.name, f.desc.as_deref(), query)
-                .map(|score| (f, score))
+                .map(|score| (*f, score))
         })
         .collect();
 
@@ -114,7 +115,7 @@ async fn search_unix(cache: &Cache, query: &str) -> Result<()> {
             let name_score = crate::catalog_match::match_score(&f.name, f.desc.as_deref(), query);
             let full_name_score =
                 crate::catalog_match::match_score(&f.full_name, f.desc.as_deref(), query);
-            name_score.or(full_name_score).map(|score| (f, score))
+            name_score.or(full_name_score).map(|score| (*f, score))
         })
         .collect();
 
@@ -138,19 +139,33 @@ async fn search_unix(cache: &Cache, query: &str) -> Result<()> {
     });
     cask_matches.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.token.cmp(&b.0.token)));
 
-    let formula_matches: Vec<_> = formula_matches.iter().take(20).map(|(f, _)| f).collect();
-    let tap_matches: Vec<_> = tap_matches.iter().take(10).map(|(f, _)| f).collect();
-    let cask_matches: Vec<_> = cask_matches.iter().take(20).map(|(c, _)| c).collect();
+    let formula_matches: Vec<_> = formula_matches.into_iter().take(20).map(|(f, _)| f).collect();
+    let tap_matches: Vec<_> = tap_matches.into_iter().take(10).map(|(f, _)| f).collect();
+    let cask_matches: Vec<_> = cask_matches.into_iter().take(20).map(|(c, _)| c).collect();
 
-    let total = formula_matches.len() + tap_matches.len() + cask_matches.len();
+    UnixSearchResults {
+        formula_matches,
+        tap_matches,
+        cask_matches,
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn print_unix_results(
+    results: &UnixSearchResults,
+    installed_packages: &std::collections::HashMap<String, crate::install::InstalledPackage>,
+    installed_casks: &std::collections::HashMap<String, crate::cask::InstalledCask>,
+    query: &str,
+) {
+    let total = results.formula_matches.len() + results.tap_matches.len() + results.cask_matches.len();
 
     if total == 0 {
         println!("no results for '{}'", query);
-        return Ok(());
+        return;
     }
 
     println!();
-    for formula in &formula_matches {
+    for formula in &results.formula_matches {
         print_formula(
             formula,
             installed_packages.contains_key(&formula.name),
@@ -158,7 +173,7 @@ async fn search_unix(cache: &Cache, query: &str) -> Result<()> {
         );
     }
 
-    for formula in &tap_matches {
+    for formula in &results.tap_matches {
         print_formula(
             formula,
             installed_packages.contains_key(&formula.name),
@@ -166,30 +181,30 @@ async fn search_unix(cache: &Cache, query: &str) -> Result<()> {
         );
     }
 
-    for cask in &cask_matches {
+    for cask in &results.cask_matches {
         print_cask(cask, installed_casks.contains_key(&cask.token));
     }
 
     let mut parts = Vec::new();
-    if !formula_matches.is_empty() {
+    if !results.formula_matches.is_empty() {
         parts.push(format!(
             "{} {}",
-            formula_matches.len(),
-            if formula_matches.len() == 1 {
+            results.formula_matches.len(),
+            if results.formula_matches.len() == 1 {
                 "formula"
             } else {
                 "formulae"
             }
         ));
     }
-    if !tap_matches.is_empty() {
-        parts.push(format!("{} from taps", tap_matches.len()));
+    if !results.tap_matches.is_empty() {
+        parts.push(format!("{} from taps", results.tap_matches.len()));
     }
-    if !cask_matches.is_empty() {
+    if !results.cask_matches.is_empty() {
         parts.push(format!(
             "{} {}",
-            cask_matches.len(),
-            if cask_matches.len() == 1 {
+            results.cask_matches.len(),
+            if results.cask_matches.len() == 1 {
                 "cask"
             } else {
                 "casks"
@@ -197,6 +212,22 @@ async fn search_unix(cache: &Cache, query: &str) -> Result<()> {
         ));
     }
     println!("\n{}", style(parts.join(", ")).dim());
+}
+
+#[cfg(not(target_os = "windows"))]
+async fn search_unix(cache: &Cache, query: &str) -> Result<()> {
+    cache.ensure_fresh().await?;
+
+    let formulae = cache.load_all_formulae().await?;
+    let casks = cache.load_all_casks().await?;
+
+    let state = InstallState::new()?;
+    let installed_packages = state.load().await?;
+    let cask_state = CaskState::new()?;
+    let installed_casks = cask_state.load().await?;
+
+    let results = find_unix_matches(&formulae, &casks, query);
+    print_unix_results(&results, &installed_packages, &installed_casks, query);
 
     Ok(())
 }

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -139,7 +139,11 @@ fn find_unix_matches<'a>(
     });
     cask_matches.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.token.cmp(&b.0.token)));
 
-    let formula_matches: Vec<_> = formula_matches.into_iter().take(20).map(|(f, _)| f).collect();
+    let formula_matches: Vec<_> = formula_matches
+        .into_iter()
+        .take(20)
+        .map(|(f, _)| f)
+        .collect();
     let tap_matches: Vec<_> = tap_matches.into_iter().take(10).map(|(f, _)| f).collect();
     let cask_matches: Vec<_> = cask_matches.into_iter().take(20).map(|(c, _)| c).collect();
 
@@ -157,7 +161,8 @@ fn print_unix_results(
     installed_casks: &std::collections::HashMap<String, crate::cask::InstalledCask>,
     query: &str,
 ) {
-    let total = results.formula_matches.len() + results.tap_matches.len() + results.cask_matches.len();
+    let total =
+        results.formula_matches.len() + results.tap_matches.len() + results.cask_matches.len();
 
     if total == 0 {
         println!("no results for '{}'", query);


### PR DESCRIPTION
🎯 **What:** The `search_unix` function in `src/commands/search.rs` previously contained all logic for data retrieval, match filtering, and output formatting. This logic has been extracted into separate functions (`find_unix_matches` and `print_unix_results`) and a `UnixSearchResults` struct.

💡 **Why:** This refactoring improves the code health by separating the concerns, making the function adhere better to the Single Responsibility Principle, and improving the overall readability and maintainability of the module.

✅ **Verification:** Ran `cargo check`, `cargo clippy -- -D warnings`, and `cargo test` to ensure that all changes are safe and the original functionality is exactly preserved. Tests passed successfully.

✨ **Result:** The `search_unix` function is now much cleaner, acting only as a high-level orchestrator. The extracted logic is modular and easier to test or modify in the future.

---
*PR created automatically by Jules for task [1738821903643704007](https://jules.google.com/task/1738821903643704007) started by @undivisible*