### PR TITLE
🔒 Fix argument injection in git clone commands

### DIFF
--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -573,7 +573,7 @@ async fn install_from_head_task(
     spinner.set_message(format!("Cloning HEAD from {}...", head_url));
 
     let clone_output = tokio::process::Command::new("git")
-        .args(["clone", "--depth=1", head_url])
+        .args(["clone", "--depth=1", "--", head_url])
         .arg(&clone_dir)
         .output()
         .await?;

--- a/src/tap.rs
+++ b/src/tap.rs
@@ -345,6 +345,7 @@ impl TapManager {
             .arg("clone")
             .arg("--depth=1")
             .arg("--single-branch")
+            .arg("--")
             .arg(&url)
             .arg(&tap.path)
             .output()


### PR DESCRIPTION
🎯 **What:** This PR fixes an argument injection vulnerability in two places (`src/tap.rs` and `src/commands/install.rs`) where a user-controlled URL is passed to a `git clone` command.
⚠️ **Risk:** Without a `--` separator, an attacker could supply a specially crafted URL starting with a hyphen (e.g., `--upload-pack`) that Git would interpret as a command-line flag rather than a repository URL. This could lead to arbitrary command execution or other unintended behavior during the clone operation.
🛡️ **Solution:** Added the standard `--` argument separator before the user-supplied URL in the `tokio::process::Command::new("git")` arguments. This ensures that the URL is treated purely as a positional argument and never as an option.

Testing for this vulnerability in an automated way is too complex due to needing to mock or manipulate local git environments to simulate malicious payloads parsing as flags while also passing the early `Self::validate_clone_url` or URL validations without completely breaking the `Command` execution flow. The fix relies on standard, reliable Git CLI behavior.

---
*PR created automatically by Jules for task [15072526185428749699](https://jules.google.com/task/15072526185428749699) started by @undivisible*