### PR TITLE
🧪 [testing improvement] Add basic native platform test for detect_platform

### DIFF
--- a/src/bottle.rs
+++ b/src/bottle.rs
@@ -1958,4 +1958,26 @@ mod tests {
         let contents = std::fs::read_to_string(formula_cellar.path().join("file.txt")).unwrap();
         assert_eq!(contents, "extract");
     }
+
+    #[test]
+    fn test_detect_platform() {
+        let os = std::env::consts::OS;
+        let arch = std::env::consts::ARCH;
+
+        let expected = match (os, arch) {
+            ("macos", arch) => {
+                let prefix = if arch == "aarch64" { "arm64_" } else { "" };
+                let codename = macos_codename();
+                format!("{}{}", prefix, codename)
+            }
+            ("linux", "x86_64") => "x86_64_linux".to_string(),
+            ("linux", "aarch64" | "arm") => "arm64_linux".to_string(),
+            _ => "unknown".to_string(),
+        };
+
+        let actual = detect_platform();
+        assert_eq!(actual, expected);
+        assert!(!actual.is_empty());
+        assert!(!actual.contains(' '));
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed - added a test for `detect_platform` to ensure it returns the correct platform string for the native host OS and architecture without requiring complex mocking.

📊 **Coverage:** What scenarios are now tested - Tests the execution of `detect_platform` on the host machine to match OS and architecture constants, checking both expected values based on compile-time evaluation and structural invariants (not empty, no spaces).

✨ **Result:** The improvement in test coverage - increased test confidence for platform detection by verifying native platform evaluations.

---
*PR created automatically by Jules for task [1134650328161437124](https://jules.google.com/task/1134650328161437124) started by @undivisible*