### PR TITLE
🧹 [Extract installed suffix formatting logic in info command]

### DIFF
--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -56,8 +56,8 @@ pub async fn info(cache: &Cache, name: &str, cask: bool) -> Result<()> {
     info_formula(formula, name, &formulae).await
 }
 
-async fn info_formula(formula: &Formula, name: &str, formulae: &[Formula]) -> Result<()> {
-    let installed_suffix = if let Some(installed) = &formula.installed {
+fn format_formula_installed_suffix(formula: &Formula) -> String {
+    if let Some(installed) = &formula.installed {
         if !installed.is_empty() {
             let installed_versions: Vec<_> = installed.iter().map(|i| i.version.as_str()).collect();
             if installed_versions.len() == 1 {
@@ -74,7 +74,11 @@ async fn info_formula(formula: &Formula, name: &str, formulae: &[Formula]) -> Re
         }
     } else {
         String::new()
-    };
+    }
+}
+
+async fn info_formula(formula: &Formula, name: &str, formulae: &[Formula]) -> Result<()> {
+    let installed_suffix = format_formula_installed_suffix(formula);
 
     println!();
     println!(
@@ -168,6 +172,18 @@ async fn info_formula(formula: &Formula, name: &str, formulae: &[Formula]) -> Re
     Ok(())
 }
 
+fn format_cask_installed_suffix(installed_version: Option<&String>, cask_version: &str) -> String {
+    if let Some(installed_ver) = installed_version {
+        if installed_ver == cask_version {
+            " · installed".to_string()
+        } else {
+            format!(" · installed ({})", installed_ver)
+        }
+    } else {
+        String::new()
+    }
+}
+
 #[instrument(skip(cache))]
 async fn info_cask(cache: &Cache, name: &str) -> Result<()> {
     cache.ensure_fresh().await?;
@@ -191,15 +207,7 @@ async fn info_cask(cache: &Cache, name: &str) -> Result<()> {
         .or_else(|| installed_casks.get(&cask_summary.token))
         .map(|i| &i.version);
 
-    let installed_suffix = if let Some(installed_ver) = installed_version {
-        if installed_ver == &cask.version {
-            " · installed".to_string()
-        } else {
-            format!(" · installed ({})", installed_ver)
-        }
-    } else {
-        String::new()
-    };
+    let installed_suffix = format_cask_installed_suffix(installed_version, &cask.version);
 
     println!();
     println!(


### PR DESCRIPTION
🎯 **What:** Extracted the verbose `installed_suffix` formatting logic from `info_formula` into a new `format_formula_installed_suffix` function, and similarly extracted the logic from `info_cask` into `format_cask_installed_suffix` in `src/commands/info.rs`.

💡 **Why:** The string formatting code was verbose and deeply nested within the main execution flow of the `info_formula` and `info_cask` functions, which increased cognitive complexity. By extracting these into pure functions, the core logic is now significantly cleaner and more readable.

✅ **Verification:** Verified that the patch preserves exact original behavior by running `cargo check`, `cargo fmt`, `cargo clippy -- -D warnings`, and the full `cargo test` test suite. All tests pass successfully and no syntax regressions were introduced.

✨ **Result:** Improved maintainability and readability of `src/commands/info.rs` by reducing the size and complexity of the primary `info_formula` and `info_cask` functions without altering behavior.

---
*PR created automatically by Jules for task [8574556775159574320](https://jules.google.com/task/8574556775159574320) started by @undivisible*