### PR TITLE
🔒 [Fix chown privilege escalation vulnerability]

### DIFF
--- a/src/sudo.rs
+++ b/src/sudo.rs
@@ -324,7 +324,7 @@ pub fn sudo_chown_recursive(path: &Path) -> Result<()> {
     let user = get_current_user();
 
     let status = Command::new("sudo")
-        .args(["chown", "-R", &format!("{}:admin", user), "--"])
+        .args(["chown", "-R", "-h", &format!("{}:admin", user), "--"])
         .arg(&path)
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())


### PR DESCRIPTION
🎯 **What:**
The vulnerability fixed was an overly permissive recursive `chown` executed with `sudo` in `src/sudo.rs` during operations handled by `sudo_chown_recursive`. It was executing `chown -R <user> <path>` without link-following safeguards.

⚠️ **Risk:**
Executing `sudo chown -R` without the `-h` (or `--no-dereference`) flag on a potentially attacker-controlled path can lead to privilege escalation. If an attacker plants a symbolic link in the path hierarchy that points to a critical system file (like `/etc/shadow`), the `chown` command would traverse the symlink and change the system file's ownership to the attacker's user, granting them full control over it.

🛡️ **Solution:**
The solution involves modifying the arguments for the `Command::new("sudo")` invocation to explicitly include the `-h` flag (i.e. `chown -R -h`). This ensures that `chown` operates on the symbolic links themselves rather than dereferencing them, thus preventing the ownership change of unintended files.

*(Note: Direct integration testing for this behavior is complex because correctly simulating and testing actual `chown` link-following behavior fundamentally requires executing a test suite with real root privileges which is unsafe and unsupported in typical CI environments. Therefore, relying on verifying the CLI argument injection in conjunction with standard unit test passes is deemed the most appropriate validation.)*

---
*PR created automatically by Jules for task [17839238463044426559](https://jules.google.com/task/17839238463044426559) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-argument hardening on a `#[allow(dead_code)]` helper; reduces privilege-escalation risk without altering broader install/sudo flows.
> 
> **Overview**
> **Security fix** for `sudo_chown_recursive` in `src/sudo.rs`: the sudo `chown` invocation now passes **`-h`** (`--no-dereference`) alongside **`-R`**, so ownership changes apply to symlinks themselves instead of following them into sensitive paths (e.g. `/etc/shadow`).
> 
> No other behavior in that helper changes—same user/group (`<user>:admin`), path normalization, and non-fatal handling on chown failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a771d72f9be7676632f8893c213b98e1c842b11f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->