### PR TITLE
🧹 [remove unused scan_cask_version_dir]

### DIFF
--- a/src/cask.rs
+++ b/src/cask.rs
@@ -441,11 +441,6 @@ impl CaskState {
         Ok(casks)
     }
 
-    #[allow(dead_code)]
-    async fn scan_cask_version_dir(&self, cask_path: &Path) -> Result<(String, i64)> {
-        Ok(latest_caskroom_version(cask_path).unwrap_or_else(|| ("unknown".to_string(), 0)))
-    }
-
     pub async fn sync_from_caskrooms(&self) -> Result<HashSet<String>> {
         let _guard = cask_state_write_lock().lock().await;
         let _file_lock =


### PR DESCRIPTION
🎯 **What:** Removed the unused `scan_cask_version_dir` function in `src/cask.rs` lines 444-447.
💡 **Why:** The function was annotated with `#[allow(dead_code)]` and was not called anywhere in the codebase. Removing it reduces dead code and improves maintainability.
✅ **Verification:** Verified by running `cargo check`, `cargo test`, `cargo fmt`, and `cargo clippy -- -D warnings`. All passing successfully.
✨ **Result:** Cleaned up code and removed unused function, improving overall codebase cleanliness.

---
*PR created automatically by Jules for task [8128245233135573903](https://jules.google.com/task/8128245233135573903) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure dead-code removal with no call sites or behavior changes.
> 
> **Overview**
> Removes the dead **`scan_cask_version_dir`** helper from **`src/cask.rs`**, including its **`#[allow(dead_code)]`** attribute.
> 
> That wrapper only delegated to **`latest_caskroom_version`** (with an **`"unknown"`** fallback) and had no callers; caskroom sync already invokes **`latest_caskroom_version`** directly in **`sync_from_caskrooms`**, so behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be826ef5b47dee23210b585331ccaaa81686dc26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->