### PR TITLE
🧪 [testing improvement] Add missing tests for Windows state management

### DIFF
--- a/src/windows_state.rs
+++ b/src/windows_state.rs
@@ -426,4 +426,68 @@ mod tests {
             .to_string();
         assert!(err.contains("already owned by scoop/tool"));
     }
+
+    #[test]
+    fn load_manifest_returns_none_when_missing() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::env::set_var("HOME", tmp.path());
+
+        let result = load_manifest(Ecosystem::Scoop, "missing-package").unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn load_manifest_returns_error_on_invalid_json() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::env::set_var("HOME", tmp.path());
+
+        let path = manifest_path(Ecosystem::Scoop, "corrupt").unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "{ invalid json").unwrap();
+
+        let err = load_manifest(Ecosystem::Scoop, "corrupt").unwrap_err();
+        assert!(matches!(err, WaxError::JsonError(_)));
+    }
+
+    #[test]
+    fn list_manifests_returns_empty_when_dir_missing() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::env::set_var("HOME", tmp.path());
+
+        let result = list_manifests().unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn list_manifests_ignores_non_json_files() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::env::set_var("HOME", tmp.path());
+
+        let dir = manifest_dir().unwrap();
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // Valid manifest
+        let manifest = WindowsPackageManifest::new(
+            Ecosystem::Scoop,
+            "valid",
+            "1.0.0",
+            "https://example.invalid/valid.zip",
+            wax_windows_root().unwrap().join("scoop-apps/valid/1.0.0"),
+            Vec::new(),
+            Vec::new(),
+        );
+        manifest.save().unwrap();
+
+        // Invalid files that should be ignored
+        std::fs::write(dir.join("ignore.txt"), "not json").unwrap();
+        std::fs::create_dir_all(dir.join("ignore.json")).unwrap();
+
+        let list = list_manifests().unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].id, "valid");
+    }
 }


### PR DESCRIPTION
🎯 **What:**
The task addresses a testing gap in `src/windows_state.rs` by adding tests for the `load_manifest` and `list_manifests` functions, utilizing a temporary filesystem to simulate scenarios without affecting the host environment.

📊 **Coverage:**
The newly added test functions are:
- `load_manifest_returns_none_when_missing`: Ensures fetching a non-existent manifest returns `Ok(None)`.
- `load_manifest_returns_error_on_invalid_json`: Ensures reading a malformed JSON file yields a `WaxError::JsonError`.
- `list_manifests_returns_empty_when_dir_missing`: Ensures listing manifests from an uncreated directory returns an empty vector without panicking.
- `list_manifests_ignores_non_json_files`: Validates that `list_manifests` strictly reads `.json` files and skips over text files and nested directories named `.json`.

✨ **Result:**
Test coverage and confidence for core Windows state management processes have been substantially improved. Code reliability against misconfigured files and filesystem edge-cases is now properly verified via CI.

---
*PR created automatically by Jules for task [3114302887377030763](https://jules.google.com/task/3114302887377030763) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code modifications.
> 
> **Overview**
> Adds **four unit tests** in `windows_state.rs` for manifest I/O helpers, using the existing `ENV_LOCK` + temporary `HOME` pattern so tests do not touch the real wax layout.
> 
> **`load_manifest`:** missing file returns `Ok(None)`; corrupt JSON on disk surfaces `WaxError::JsonError`.
> 
> **`list_manifests`:** missing manifests directory returns an empty list; only regular `.json` files are loaded—`.txt` files and a directory named `ignore.json` are skipped while a saved valid manifest is still listed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2907f921e0d548bde4bc4edefd4644b1d5f4a80b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->