### PR TITLE
🧪 Add tests for is_running_as_root and has_sudo_cached in src/sudo.rs

### DIFF
--- a/src/sudo.rs
+++ b/src/sudo.rs
@@ -340,12 +340,11 @@ pub fn sudo_chown_recursive(path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     #[cfg(unix)]
-    use super::is_running_as_root;
-    #[cfg(unix)]
     use super::sudo_copy;
     use super::{
-        acquire_sudo_for, is_file_exists_error, is_permission_error, normalize_path,
-        sudo_password_prompt, MOCK_INTERACTIVE_TERMINAL, SUDO_VALIDATED, SUDO_VALIDATED_AT,
+        acquire_sudo_for, has_sudo_cached, is_file_exists_error, is_permission_error,
+        is_running_as_root, normalize_path, now_unix_secs, sudo_password_prompt,
+        MOCK_INTERACTIVE_TERMINAL, SUDO_CACHE_TTL_SECS, SUDO_VALIDATED, SUDO_VALIDATED_AT,
     };
     use crate::error::WaxError;
     use std::io::{Error, ErrorKind};
@@ -578,12 +577,119 @@ fi
             "failure" => {
                 "#!/bin/sh\nexit 1\n"
             }
+            "cached" => {
+                "#!/bin/sh\nif [ \"$1\" = \"-n\" ] && [ \"$2\" = \"true\" ]; then\n    exit 0\nfi\nexit 1\n"
+            }
             _ => "#!/bin/sh\nexit 1\n",
         };
         std::fs::write(&sudo_path, script).unwrap();
         let mut perms = std::fs::metadata(&sudo_path).unwrap().permissions();
         perms.set_mode(0o755);
         std::fs::set_permissions(&sudo_path, perms).unwrap();
+    }
+
+    #[test]
+    fn test_is_running_as_root() {
+        // Just verify it doesn't panic and returns a boolean
+        let is_root = is_running_as_root();
+        #[cfg(unix)]
+        {
+            let actual_root = unsafe { libc::geteuid() == 0 };
+            assert_eq!(is_root, actual_root);
+        }
+        #[cfg(not(unix))]
+        {
+            assert_eq!(is_root, false);
+        }
+    }
+
+    #[test]
+    fn test_has_sudo_cached_when_already_validated() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _env_guard = EnvGuard::new();
+
+        SUDO_VALIDATED.store(true, Ordering::SeqCst);
+        SUDO_VALIDATED_AT.store(now_unix_secs(), Ordering::SeqCst);
+
+        // Since it's validated, it should return true immediately without calling sudo.
+        assert!(has_sudo_cached());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_has_sudo_cached_when_expired() {
+        if is_running_as_root() {
+            return;
+        }
+
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _env_guard = EnvGuard::new();
+
+        // Setup a failing fake sudo so if it falls back to checking, it returns false
+        let temp_dir = tempfile::tempdir().unwrap();
+        setup_fake_sudo(temp_dir.path(), "failure");
+        let mut new_path = temp_dir.path().to_path_buf().into_os_string();
+        new_path.push(":");
+        new_path.push(&_env_guard.original_path);
+        std::env::set_var("PATH", new_path);
+
+        SUDO_VALIDATED.store(true, Ordering::SeqCst);
+        // Set timestamp far in the past to simulate expiration
+        SUDO_VALIDATED_AT.store(now_unix_secs().saturating_sub(SUDO_CACHE_TTL_SECS + 10), Ordering::SeqCst);
+
+        assert!(!has_sudo_cached());
+        assert!(!SUDO_VALIDATED.load(Ordering::SeqCst));
+        assert_eq!(SUDO_VALIDATED_AT.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_has_sudo_cached_when_unset_and_cached() {
+        if is_running_as_root() {
+            return;
+        }
+
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _env_guard = EnvGuard::new();
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        setup_fake_sudo(temp_dir.path(), "cached");
+        let mut new_path = temp_dir.path().to_path_buf().into_os_string();
+        new_path.push(":");
+        new_path.push(&_env_guard.original_path);
+        std::env::set_var("PATH", new_path);
+
+        SUDO_VALIDATED.store(false, Ordering::SeqCst);
+        SUDO_VALIDATED_AT.store(0, Ordering::SeqCst);
+
+        assert!(has_sudo_cached());
+        assert!(SUDO_VALIDATED.load(Ordering::SeqCst));
+        assert!(SUDO_VALIDATED_AT.load(Ordering::SeqCst) > 0);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_has_sudo_cached_when_unset_and_failure() {
+        if is_running_as_root() {
+            return;
+        }
+
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _env_guard = EnvGuard::new();
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        setup_fake_sudo(temp_dir.path(), "failure");
+        let mut new_path = temp_dir.path().to_path_buf().into_os_string();
+        new_path.push(":");
+        new_path.push(&_env_guard.original_path);
+        std::env::set_var("PATH", new_path);
+
+        SUDO_VALIDATED.store(false, Ordering::SeqCst);
+        SUDO_VALIDATED_AT.store(0, Ordering::SeqCst);
+
+        assert!(!has_sudo_cached());
+        assert!(!SUDO_VALIDATED.load(Ordering::SeqCst));
+        assert_eq!(SUDO_VALIDATED_AT.load(Ordering::SeqCst), 0);
     }
 
     #[test]

--- a/src/sudo.rs
+++ b/src/sudo.rs
@@ -635,7 +635,10 @@ fi
 
         SUDO_VALIDATED.store(true, Ordering::SeqCst);
         // Set timestamp far in the past to simulate expiration
-        SUDO_VALIDATED_AT.store(now_unix_secs().saturating_sub(SUDO_CACHE_TTL_SECS + 10), Ordering::SeqCst);
+        SUDO_VALIDATED_AT.store(
+            now_unix_secs().saturating_sub(SUDO_CACHE_TTL_SECS + 10),
+            Ordering::SeqCst,
+        );
 
         assert!(!has_sudo_cached());
         assert!(!SUDO_VALIDATED.load(Ordering::SeqCst));


### PR DESCRIPTION
🎯 **What:** This PR addresses a testing gap by adding unit tests for the `is_running_as_root` and `has_sudo_cached` functions in `src/sudo.rs`.

📊 **Coverage:** The tests thoroughly verify all states for caching whether sudo requires a password. Scenarios covered include:
- When the cache is valid and not expired.
- When the cache is valid but expired.
- When the cache is unset and a background check succeeds.
- When the cache is unset and a background check fails.
It also includes basic testing for `is_running_as_root`.

✨ **Result:** Test coverage for the `sudo.rs` module has increased, assuring stability and preventing regressions when interacting with the system's `sudo` command. Tests use existing thread-safe lock and environment injection guards.

---
*PR created automatically by Jules for task [7607957826403756639](https://jules.google.com/task/7607957826403756639) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in src/sudo.rs; no runtime sudo or privilege logic is modified.
> 
> **Overview**
> Adds unit tests in `src/sudo.rs` for **`has_sudo_cached`** and **`is_running_as_root`**, with no changes to production sudo behavior.
> 
> **`has_sudo_cached`** is covered for a fresh in-memory cache hit, TTL expiry (cache cleared and `sudo -n true` consulted via a fake `sudo`), and the unset-cache paths when `sudo -n true` succeeds or fails. Tests reuse **`ENV_LOCK`**, **`EnvGuard`**, and **`setup_fake_sudo`**, including a new **`cached`** fake that exits 0 for `sudo -n true`.
> 
> **`is_running_as_root`** gets a smoke test that matches **`geteuid() == 0`** on Unix and expects false elsewhere. Test-module imports are consolidated so helpers like **`now_unix_secs`** and **`SUDO_CACHE_TTL_SECS`** are available to the new cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dec97cd37ea8cc3f1ddde939e6b66a887de50b81. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->