### PR TITLE
🧹 [Code Health] Replace allow(dead_code) with cfg in discovery module

### DIFF
--- a/src/adopt.rs
+++ b/src/adopt.rs
@@ -6,9 +6,12 @@
 
 use crate::cache::Cache;
 use crate::cask::{CaskState, InstalledCask};
-use crate::discovery::{
-    discover_linux_system_packages, discover_manually_installed_casks, normalize_package_token,
-};
+#[cfg(target_os = "linux")]
+use crate::discovery::discover_linux_system_packages;
+#[cfg(target_os = "macos")]
+use crate::discovery::discover_manually_installed_casks;
+#[cfg(target_os = "macos")]
+use crate::discovery::normalize_package_token;
 use crate::error::{Result, WaxError};
 use crate::install::{InstallState, InstalledPackage};
 use std::collections::{HashMap, HashSet};
@@ -73,6 +76,7 @@ pub fn short_package_name(name: &str) -> &str {
     name.rsplit('/').next().unwrap_or(name)
 }
 
+#[cfg(target_os = "macos")]
 pub fn merge_discovered_casks(
     installed_casks: &mut HashMap<String, InstalledCask>,
     discovered_casks: HashMap<String, InstalledCask>,
@@ -118,6 +122,7 @@ pub fn merge_discovered_casks(
     }
 }
 
+#[cfg(target_os = "macos")]
 fn manual_app_key(cask: &InstalledCask) -> Option<String> {
     if cask.artifact_type.as_deref() != Some("app") {
         return None;
@@ -151,7 +156,8 @@ pub async fn sync_installed_state(
         }
         let mut formulae = state.load().await?;
 
-        if cfg!(target_os = "linux") {
+        #[cfg(target_os = "linux")]
+        {
             let all_formulae = cache.load_all_formulae().await?;
             for (name, package) in discover_linux_system_packages(&all_formulae).await? {
                 formulae.entry(name).or_insert(package);
@@ -173,9 +179,11 @@ pub async fn sync_installed_state(
                 Default::default()
             }
         };
+        #[allow(unused_mut)]
         let mut casks = cask_state.load().await?;
 
-        if cfg!(target_os = "macos") {
+        #[cfg(target_os = "macos")]
+        {
             let all_casks = cache.load_all_casks().await?;
             let discovered = discover_manually_installed_casks(&all_casks).await?;
             merge_discovered_casks(&mut casks, discovered, &caskroom_synced_names);
@@ -246,6 +254,7 @@ async fn lookup_cask(
         });
     }
 
+    #[cfg(target_os = "macos")]
     if let Some(app_name) = crate::discovery::manually_installed_app_matching(name).await {
         return Err(manual_app_not_installed_error(name, &app_name));
     }
@@ -253,6 +262,7 @@ async fn lookup_cask(
     Err(WaxError::NotInstalled(name.to_string()))
 }
 
+#[cfg(target_os = "macos")]
 fn manual_app_not_installed_error(requested_name: &str, app_name: &str) -> WaxError {
     WaxError::NotInstalled(format!(
         "{requested_name}\n  Found /Applications/{app_name}, but it is not managed by Wax. Wax will not remove it automatically; remove it in Finder or with that app's supported uninstaller."
@@ -261,10 +271,15 @@ fn manual_app_not_installed_error(requested_name: &str, app_name: &str) -> WaxEr
 
 #[cfg(test)]
 mod tests {
-    use super::{manual_app_not_installed_error, merge_discovered_casks, short_package_name};
+    use super::short_package_name;
+    #[cfg(target_os = "macos")]
+    use super::{manual_app_not_installed_error, merge_discovered_casks};
+    #[cfg(target_os = "macos")]
     use crate::cask::InstalledCask;
+    #[allow(unused_imports)]
     use std::collections::{HashMap, HashSet};
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn manual_app_suggestion_keeps_removal_explicit() {
         let error = manual_app_not_installed_error("raycast@beta", "Raycast Beta.app");
@@ -279,6 +294,7 @@ mod tests {
         assert_eq!(short_package_name("vro"), "vro");
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn merge_discovered_casks_updates_existing_versions() {
         let mut installed = HashMap::from([(
@@ -315,6 +331,7 @@ mod tests {
         assert_eq!(cask.app_name.as_deref(), Some("Example.app"));
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn merge_discovered_casks_preserves_caskroom_synced_versions() {
         let mut installed = HashMap::from([(
@@ -353,6 +370,7 @@ mod tests {
         assert_eq!(cask.install_date, 2);
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn merge_discovered_casks_replaces_stale_manual_app_token() {
         let mut installed = HashMap::from([(
@@ -386,6 +404,7 @@ mod tests {
         assert_eq!(installed.get("vendor-example").unwrap().version, "2.0.0");
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn merge_discovered_casks_keeps_caskroom_synced_same_app_token() {
         let mut installed = HashMap::from([(

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -51,115 +51,116 @@ struct CaskMatch {
 #[cfg(target_os = "macos")]
 pub async fn discover_manually_installed_casks(
     casks: &[Cask],
-) -> Result<HashMap<String, InstalledCask>> {        // Match application bundles against every known cask token/name alias,
-        // but keep all candidates so ambiguous names can be resolved by
-        // stronger bundle metadata instead of whichever cask appears first.
-        let candidate_index = build_cask_candidate_index(casks);
-        let mut discovered = HashMap::new();
+) -> Result<HashMap<String, InstalledCask>> {
+    // Match application bundles against every known cask token/name alias,
+    // but keep all candidates so ambiguous names can be resolved by
+    // stronger bundle metadata instead of whichever cask appears first.
+    let candidate_index = build_cask_candidate_index(casks);
+    let mut discovered = HashMap::new();
 
-        // Scan the standard application roots so manually installed apps are
-        // visible to Wax even when they were not installed through brew.
-        for root in macos_application_roots() {
-            if !root.exists() {
+    // Scan the standard application roots so manually installed apps are
+    // visible to Wax even when they were not installed through brew.
+    for root in macos_application_roots() {
+        if !root.exists() {
+            continue;
+        }
+
+        let mut entries = match tokio::fs::read_dir(&root).await {
+            Ok(entries) => entries,
+            Err(err) => {
+                debug!("Skipping {:?}: {}", root, err);
+                continue;
+            }
+        };
+
+        while let Some(entry) = entries.next_entry().await? {
+            let path = entry.path();
+            let file_name = entry.file_name().to_string_lossy().to_string();
+
+            if !path.is_dir() && !path.is_symlink() {
+                continue;
+            }
+            if !file_name.ends_with(".app") {
+                continue;
+            }
+            if file_name.starts_with('.') {
                 continue;
             }
 
-            let mut entries = match tokio::fs::read_dir(&root).await {
-                Ok(entries) => entries,
-                Err(err) => {
-                    debug!("Skipping {:?}: {}", root, err);
-                    continue;
-                }
+            let app = read_app_bundle_metadata(&path, &file_name).await;
+            let Some(cask_match) = resolve_cask_match(casks, &candidate_index, &app) else {
+                continue;
             };
+            let cask = &casks[cask_match.cask_index];
 
-            while let Some(entry) = entries.next_entry().await? {
-                let path = entry.path();
-                let file_name = entry.file_name().to_string_lossy().to_string();
+            let version = cask_match.version.unwrap_or_else(|| "unknown".to_string());
+            let install_date = entry
+                .metadata()
+                .await
+                .ok()
+                .and_then(|m| m.modified().ok())
+                .and_then(system_time_to_unix_seconds)
+                .unwrap_or_else(unix_seconds_now);
 
-                if !path.is_dir() && !path.is_symlink() {
-                    continue;
-                }
-                if !file_name.ends_with(".app") {
-                    continue;
-                }
-                if file_name.starts_with('.') {
-                    continue;
-                }
-
-                let app = read_app_bundle_metadata(&path, &file_name).await;
-                let Some(cask_match) = resolve_cask_match(casks, &candidate_index, &app) else {
-                    continue;
-                };
-                let cask = &casks[cask_match.cask_index];
-
-                let version = cask_match.version.unwrap_or_else(|| "unknown".to_string());
-                let install_date = entry
-                    .metadata()
-                    .await
-                    .ok()
-                    .and_then(|m| m.modified().ok())
-                    .and_then(system_time_to_unix_seconds)
-                    .unwrap_or_else(unix_seconds_now);
-
-                discovered
-                    .entry(cask.token.clone())
-                    .or_insert_with(|| InstalledCask {
-                        name: cask.token.clone(),
-                        version,
-                        install_date,
-                        artifact_type: Some("app".to_string()),
-                        binary_paths: None,
-                        app_name: Some(app.bundle_name),
-                        installed_paths: Vec::new(),
-                    });
-            }
+            discovered
+                .entry(cask.token.clone())
+                .or_insert_with(|| InstalledCask {
+                    name: cask.token.clone(),
+                    version,
+                    install_date,
+                    artifact_type: Some("app".to_string()),
+                    binary_paths: None,
+                    app_name: Some(app.bundle_name),
+                    installed_paths: Vec::new(),
+                });
         }
+    }
 
-        if !discovered.is_empty() {
-            info!(
-                "Discovered {} cask(s) from manual installs in application roots",
-                discovered.len()
-            );
-        }
-        Ok(discovered)
+    if !discovered.is_empty() {
+        info!(
+            "Discovered {} cask(s) from manual installs in application roots",
+            discovered.len()
+        );
+    }
+    Ok(discovered)
 }
 
 #[cfg(target_os = "linux")]
 pub async fn discover_linux_system_packages(
     formulae: &[Formula],
-) -> Result<HashMap<String, InstalledPackage>> {        // Normalize package-manager names so dpkg/rpm entries can be matched
-        // back to the canonical Homebrew formula name.
-        let token_index = build_formula_token_index(formulae);
-        let mut discovered = HashMap::new();
+) -> Result<HashMap<String, InstalledPackage>> {
+    // Normalize package-manager names so dpkg/rpm entries can be matched
+    // back to the canonical Homebrew formula name.
+    let token_index = build_formula_token_index(formulae);
+    let mut discovered = HashMap::new();
 
-        for (name, version) in read_linux_package_inventory().await? {
-            let Some(formula_name) = token_index.get(&normalize_package_token(&name)).cloned()
-            else {
-                continue;
-            };
+    for (name, version) in read_linux_package_inventory().await? {
+        let Some(formula_name) = token_index.get(&normalize_package_token(&name)).cloned() else {
+            continue;
+        };
 
-            discovered
-                .entry(formula_name.clone())
-                .or_insert_with(|| InstalledPackage {
-                    name: formula_name,
-                    version,
-                    platform: detect_platform(),
-                    install_date: unix_seconds_now(),
-                    install_mode: InstallMode::Global,
-                    from_source: false,
-                    bottle_rebuild: 0,
-                    bottle_sha256: None,
-                    pinned: false,
-                });
-        }
+        discovered
+            .entry(formula_name.clone())
+            .or_insert_with(|| InstalledPackage {
+                name: formula_name,
+                version,
+                platform: detect_platform(),
+                install_date: unix_seconds_now(),
+                install_mode: InstallMode::Global,
+                from_source: false,
+                bottle_rebuild: 0,
+                bottle_sha256: None,
+                pinned: false,
+            });
+    }
 
-        if !discovered.is_empty() {
-            info!(
-                "Discovered {} Linux package(s) from dpkg/rpm inventories",
-                discovered.len()
-            );
-        }
-        Ok(discovered)
+    if !discovered.is_empty() {
+        info!(
+            "Discovered {} Linux package(s) from dpkg/rpm inventories",
+            discovered.len()
+        );
+    }
+    Ok(discovered)
 }
 
 #[cfg(target_os = "macos")]
@@ -181,27 +182,29 @@ pub(crate) fn matching_manual_app_name<'a>(
 }
 
 #[cfg(target_os = "macos")]
-pub async fn manually_installed_app_matching(requested_name: &str) -> Option<String> {        for root in macos_application_roots() {
-            let Ok(mut entries) = tokio::fs::read_dir(root).await else {
+pub async fn manually_installed_app_matching(requested_name: &str) -> Option<String> {
+    for root in macos_application_roots() {
+        let Ok(mut entries) = tokio::fs::read_dir(root).await else {
+            continue;
+        };
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            let path = entry.path();
+            let file_name = entry.file_name().to_string_lossy().to_string();
+            if !file_name.ends_with(".app") || (!path.is_dir() && !path.is_symlink()) {
                 continue;
-            };
-            while let Ok(Some(entry)) = entries.next_entry().await {
-                let path = entry.path();
-                let file_name = entry.file_name().to_string_lossy().to_string();
-                if !file_name.ends_with(".app") || (!path.is_dir() && !path.is_symlink()) {
-                    continue;
-                }
-                let app = read_app_bundle_metadata(&path, &file_name).await;
-                if matching_manual_app_name(
-                    requested_name,
-                    [file_name.as_str(), app.bundle_name.as_str()],
-                )
-                .is_some()
-                {
-                    return Some(file_name);
-                }
             }
-        }        None
+            let app = read_app_bundle_metadata(&path, &file_name).await;
+            if matching_manual_app_name(
+                requested_name,
+                [file_name.as_str(), app.bundle_name.as_str()],
+            )
+            .is_some()
+            {
+                return Some(file_name);
+            }
+        }
+    }
+    None
 }
 
 #[cfg(target_os = "macos")]
@@ -479,31 +482,33 @@ fn combine_bundle_version_for_cask(
 }
 
 #[cfg(target_os = "macos")]
-async fn read_info_plist_string(path: &Path, key: &str) -> Option<String> {        let plist = path.join("Contents/Info.plist");
-        if !plist.exists() {
-            return None;
-        }
+async fn read_info_plist_string(path: &Path, key: &str) -> Option<String> {
+    let plist = path.join("Contents/Info.plist");
+    if !plist.exists() {
+        return None;
+    }
 
-        let output = Command::new("plutil")
-            .arg("-extract")
-            .arg(key)
-            .arg("raw")
-            .arg("-o")
-            .arg("-")
-            .arg(&plist)
-            .output()
-            .await
-            .ok()?;
+    let output = Command::new("plutil")
+        .arg("-extract")
+        .arg(key)
+        .arg("raw")
+        .arg("-o")
+        .arg("-")
+        .arg(&plist)
+        .output()
+        .await
+        .ok()?;
 
-        if !output.status.success() {
-            return None;
-        }
+    if !output.status.success() {
+        return None;
+    }
 
-        let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if value.is_empty() {
-            None        } else {
-            Some(value)
-        }
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -731,7 +736,7 @@ mod tests {
     }
 
     #[cfg(target_os = "macos")]
-#[test]
+    #[test]
     fn matches_manual_beta_app_to_versioned_request() {
         assert_eq!(
             matching_manual_app_name("raycast@beta", ["Raycast Beta.app"]),
@@ -745,7 +750,7 @@ mod tests {
     }
 
     #[cfg(target_os = "macos")]
-#[test]
+    #[test]
     fn matches_cask_aliases() {
         let cask = Cask {
             token: "google-chrome".to_string(),
@@ -774,7 +779,7 @@ mod tests {
     }
 
     #[cfg(target_os = "macos")]
-fn test_cask(token: &str, names: &[&str], homepage: &str, version: &str) -> Cask {
+    fn test_cask(token: &str, names: &[&str], homepage: &str, version: &str) -> Cask {
         Cask {
             token: token.to_string(),
             full_token: token.to_string(),
@@ -789,7 +794,7 @@ fn test_cask(token: &str, names: &[&str], homepage: &str, version: &str) -> Cask
     }
 
     #[cfg(target_os = "macos")]
-#[test]
+    #[test]
     fn prefers_exact_version_when_app_name_is_ambiguous() {
         let casks = vec![
             test_cask("example", &["Example"], "https://example.invalid/", "9.9.9"),
@@ -815,7 +820,7 @@ fn test_cask(token: &str, names: &[&str], homepage: &str, version: &str) -> Cask
     }
 
     #[cfg(target_os = "macos")]
-#[test]
+    #[test]
     fn uses_bundle_identifier_to_break_ambiguous_app_name_tie() {
         let casks = vec![
             test_cask("example", &["Example"], "https://example.invalid/", "9.9.9"),
@@ -840,7 +845,7 @@ fn test_cask(token: &str, names: &[&str], homepage: &str, version: &str) -> Cask
     }
 
     #[cfg(target_os = "macos")]
-#[test]
+    #[test]
     fn does_not_guess_when_app_name_is_ambiguous() {
         let casks = vec![
             test_cask("example", &["Example"], "https://example.invalid/", "9.9.9"),
@@ -864,7 +869,7 @@ fn test_cask(token: &str, names: &[&str], homepage: &str, version: &str) -> Cask
     }
 
     #[cfg(target_os = "macos")]
-#[test]
+    #[test]
     fn combines_bundle_version_when_cask_uses_build_suffix() {
         assert_eq!(
             combine_bundle_version_for_cask("1.2.3", "456", "1.2.3,456"),

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -5,9 +5,13 @@
 //! specific locations and merge any matches back into Wax’s installed-package
 //! view so lockfiles, sync, and status commands stay accurate.
 
-use crate::api::{Cask, Formula};
+#[cfg(target_os = "macos")]
+use crate::api::Cask;
+#[cfg(target_os = "linux")]
+use crate::api::Formula;
 #[cfg_attr(not(target_os = "linux"), allow(unused_imports))]
 use crate::bottle::detect_platform;
+#[cfg(target_os = "macos")]
 use crate::cask::InstalledCask;
 use crate::error::Result;
 #[cfg_attr(not(target_os = "linux"), allow(unused_imports))]
@@ -15,6 +19,7 @@ use crate::install::{InstallMode, InstalledPackage};
 #[cfg(target_os = "macos")]
 use crate::ui::dirs;
 use std::collections::HashMap;
+#[cfg(target_os = "macos")]
 use std::path::Path;
 #[cfg(target_os = "macos")]
 use std::path::PathBuf;
@@ -26,6 +31,7 @@ use tracing::debug;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use tracing::info;
 
+#[cfg(target_os = "macos")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct AppBundleMetadata {
     bundle_name: String,
@@ -35,25 +41,17 @@ struct AppBundleMetadata {
     bundle_version: Option<String>,
 }
 
+#[cfg(target_os = "macos")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct CaskMatch {
     cask_index: usize,
     version: Option<String>,
 }
 
-#[allow(dead_code)]
+#[cfg(target_os = "macos")]
 pub async fn discover_manually_installed_casks(
     casks: &[Cask],
-) -> Result<HashMap<String, InstalledCask>> {
-    #[cfg(not(target_os = "macos"))]
-    {
-        let _ = casks;
-        Ok(HashMap::new())
-    }
-
-    #[cfg(target_os = "macos")]
-    {
-        // Match application bundles against every known cask token/name alias,
+) -> Result<HashMap<String, InstalledCask>> {        // Match application bundles against every known cask token/name alias,
         // but keep all candidates so ambiguous names can be resolved by
         // stronger bundle metadata instead of whichever cask appears first.
         let candidate_index = build_cask_candidate_index(casks);
@@ -123,25 +121,13 @@ pub async fn discover_manually_installed_casks(
                 discovered.len()
             );
         }
-
         Ok(discovered)
-    }
 }
 
-#[allow(dead_code)]
-#[allow(clippy::needless_return)]
+#[cfg(target_os = "linux")]
 pub async fn discover_linux_system_packages(
     formulae: &[Formula],
-) -> Result<HashMap<String, InstalledPackage>> {
-    #[cfg(not(target_os = "linux"))]
-    {
-        let _ = formulae;
-        return Ok(HashMap::new());
-    }
-
-    #[cfg(target_os = "linux")]
-    {
-        // Normalize package-manager names so dpkg/rpm entries can be matched
+) -> Result<HashMap<String, InstalledPackage>> {        // Normalize package-manager names so dpkg/rpm entries can be matched
         // back to the canonical Homebrew formula name.
         let token_index = build_formula_token_index(formulae);
         let mut discovered = HashMap::new();
@@ -173,12 +159,10 @@ pub async fn discover_linux_system_packages(
                 discovered.len()
             );
         }
-
         Ok(discovered)
-    }
 }
 
-#[allow(dead_code)]
+#[cfg(target_os = "macos")]
 pub(crate) fn matching_manual_app_name<'a>(
     requested_name: &str,
     app_names: impl IntoIterator<Item = &'a str>,
@@ -196,17 +180,8 @@ pub(crate) fn matching_manual_app_name<'a>(
         .map(str::to_owned)
 }
 
-#[allow(dead_code)]
-pub async fn manually_installed_app_matching(requested_name: &str) -> Option<String> {
-    #[cfg(not(target_os = "macos"))]
-    {
-        let _ = requested_name;
-        None
-    }
-
-    #[cfg(target_os = "macos")]
-    {
-        for root in macos_application_roots() {
+#[cfg(target_os = "macos")]
+pub async fn manually_installed_app_matching(requested_name: &str) -> Option<String> {        for root in macos_application_roots() {
             let Ok(mut entries) = tokio::fs::read_dir(root).await else {
                 continue;
             };
@@ -226,12 +201,10 @@ pub async fn manually_installed_app_matching(requested_name: &str) -> Option<Str
                     return Some(file_name);
                 }
             }
-        }
-        None
-    }
+        }        None
 }
 
-#[allow(dead_code)]
+#[cfg(target_os = "macos")]
 fn build_cask_candidate_index(casks: &[Cask]) -> HashMap<String, Vec<usize>> {
     let mut index = HashMap::new();
 
@@ -249,7 +222,7 @@ fn build_cask_candidate_index(casks: &[Cask]) -> HashMap<String, Vec<usize>> {
     index
 }
 
-#[allow(dead_code)]
+#[cfg(target_os = "linux")]
 fn build_formula_token_index(formulae: &[Formula]) -> HashMap<String, String> {
     let mut index = HashMap::new();
 
@@ -265,14 +238,14 @@ fn build_formula_token_index(formulae: &[Formula]) -> HashMap<String, String> {
     index
 }
 
-#[allow(dead_code)]
+#[cfg(target_os = "macos")]
 fn cask_tokens(cask: &Cask) -> Vec<String> {
     let mut aliases = vec![cask.token.clone(), cask.full_token.clone()];
     aliases.extend(cask.name.clone());
     aliases
 }
 
-#[allow(dead_code)]
+#[cfg(target_os = "macos")]
 fn candidate_indices_for_value(
     candidate_index: &HashMap<String, Vec<usize>>,
     value: &str,
@@ -296,7 +269,7 @@ fn candidate_indices_for_value(
     candidates
 }
 
-#[allow(dead_code)]
+#[cfg(target_os = "macos")]
 fn resolve_cask_match(
     casks: &[Cask],
     candidate_index: &HashMap<String, Vec<usize>>,
@@ -344,7 +317,7 @@ fn resolve_cask_match(
     }
 }
 
-#[allow(dead_code)]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 pub(crate) fn normalize_package_token(value: &str) -> String {
     let value = value
         .replace(".app", "")
@@ -378,6 +351,7 @@ pub(crate) fn normalize_package_token(value: &str) -> String {
     out.trim_matches('-').to_string()
 }
 
+#[cfg(target_os = "macos")]
 fn cask_match_score(app: &AppBundleMetadata, cask: &Cask) -> i32 {
     let mut score = 0;
     if cask_version_matches_app(app, cask) {
@@ -389,6 +363,7 @@ fn cask_match_score(app: &AppBundleMetadata, cask: &Cask) -> i32 {
     score
 }
 
+#[cfg(target_os = "macos")]
 fn app_version_for_cask(app: &AppBundleMetadata, cask: &Cask) -> Option<String> {
     if let (Some(short), Some(bundle)) = (&app.short_version, &app.bundle_version) {
         if let Some(version) = combine_bundle_version_for_cask(short, bundle, &cask.version) {
@@ -401,6 +376,7 @@ fn app_version_for_cask(app: &AppBundleMetadata, cask: &Cask) -> Option<String> 
         .or_else(|| app.bundle_version.clone())
 }
 
+#[cfg(target_os = "macos")]
 fn cask_version_matches_app(app: &AppBundleMetadata, cask: &Cask) -> bool {
     if app
         .short_version
@@ -424,6 +400,7 @@ fn cask_version_matches_app(app: &AppBundleMetadata, cask: &Cask) -> bool {
     false
 }
 
+#[cfg(target_os = "macos")]
 fn bundle_identifier_matches_cask(bundle_identifier: Option<&str>, cask: &Cask) -> bool {
     let Some(vendor) = bundle_identifier_vendor(bundle_identifier) else {
         return false;
@@ -438,6 +415,7 @@ fn bundle_identifier_matches_cask(bundle_identifier: Option<&str>, cask: &Cask) 
         || homepage.split('-').any(|part| part == vendor)
 }
 
+#[cfg(target_os = "macos")]
 fn bundle_identifier_vendor(bundle_identifier: Option<&str>) -> Option<String> {
     let common_prefixes = ["app", "co", "com", "io", "net", "org"];
     bundle_identifier?
@@ -468,7 +446,7 @@ async fn read_app_bundle_metadata(path: &Path, file_name: &str) -> AppBundleMeta
     }
 }
 
-#[allow(dead_code)]
+#[cfg(target_os = "macos")]
 async fn read_app_bundle_name(path: &Path) -> Option<String> {
     if let Some(name) = read_info_plist_string(path, "CFBundleDisplayName").await {
         return Some(name);
@@ -482,6 +460,7 @@ async fn read_app_bundle_name(path: &Path) -> Option<String> {
         .map(|s| s.to_string())
 }
 
+#[cfg(target_os = "macos")]
 fn combine_bundle_version_for_cask(
     short_version: &str,
     bundle_version: &str,
@@ -499,17 +478,8 @@ fn combine_bundle_version_for_cask(
     }
 }
 
-async fn read_info_plist_string(path: &Path, key: &str) -> Option<String> {
-    #[cfg(not(target_os = "macos"))]
-    {
-        let _ = path;
-        let _ = key;
-        None
-    }
-
-    #[cfg(target_os = "macos")]
-    {
-        let plist = path.join("Contents/Info.plist");
+#[cfg(target_os = "macos")]
+async fn read_info_plist_string(path: &Path, key: &str) -> Option<String> {        let plist = path.join("Contents/Info.plist");
         if !plist.exists() {
             return None;
         }
@@ -531,14 +501,12 @@ async fn read_info_plist_string(path: &Path, key: &str) -> Option<String> {
 
         let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
         if value.is_empty() {
-            None
-        } else {
+            None        } else {
             Some(value)
         }
-    }
 }
 
-#[allow(dead_code)]
+#[cfg(target_os = "linux")]
 async fn read_linux_package_inventory() -> Result<Vec<(String, String)>> {
     let mut inventories = Vec::new();
 
@@ -561,7 +529,7 @@ async fn read_linux_package_inventory() -> Result<Vec<(String, String)>> {
     Ok(inventories)
 }
 
-#[allow(dead_code)]
+#[cfg(target_os = "linux")]
 async fn query_dpkg_inventory() -> Result<Option<Vec<(String, String)>>> {
     let output = Command::new("dpkg-query")
         .arg("-W")
@@ -580,7 +548,7 @@ async fn query_dpkg_inventory() -> Result<Option<Vec<(String, String)>>> {
     Ok(Some(parse_tab_inventory_lines(&output.stdout, true)))
 }
 
-#[allow(dead_code)]
+#[cfg(target_os = "linux")]
 async fn query_pacman_inventory() -> Result<Option<Vec<(String, String)>>> {
     let output = Command::new("pacman").arg("-Q").output().await;
 
@@ -595,7 +563,7 @@ async fn query_pacman_inventory() -> Result<Option<Vec<(String, String)>>> {
     Ok(Some(parse_space_inventory_lines(&output.stdout, false)))
 }
 
-#[allow(dead_code)]
+#[cfg(target_os = "linux")]
 async fn query_apk_inventory() -> Result<Option<Vec<(String, String)>>> {
     let names_output = Command::new("apk").arg("info").arg("-e").output().await;
 
@@ -628,7 +596,7 @@ async fn query_apk_inventory() -> Result<Option<Vec<(String, String)>>> {
     )))
 }
 
-#[allow(dead_code)]
+#[cfg(target_os = "linux")]
 async fn query_rpm_inventory() -> Result<Option<Vec<(String, String)>>> {
     let output = Command::new("rpm")
         .arg("-qa")
@@ -648,7 +616,7 @@ async fn query_rpm_inventory() -> Result<Option<Vec<(String, String)>>> {
     Ok(Some(parse_tab_inventory_lines(&output.stdout, false)))
 }
 
-#[allow(dead_code)]
+#[cfg(target_os = "linux")]
 fn parse_line_list(stdout: &[u8]) -> Vec<String> {
     String::from_utf8_lossy(stdout)
         .lines()
@@ -658,7 +626,7 @@ fn parse_line_list(stdout: &[u8]) -> Vec<String> {
         .collect()
 }
 
-#[allow(dead_code)]
+#[cfg(target_os = "linux")]
 fn parse_space_inventory_lines(stdout: &[u8], strip_arch_suffix: bool) -> Vec<(String, String)> {
     String::from_utf8_lossy(stdout)
         .lines()
@@ -680,7 +648,7 @@ fn parse_space_inventory_lines(stdout: &[u8], strip_arch_suffix: bool) -> Vec<(S
         .collect()
 }
 
-#[allow(dead_code)]
+#[cfg(target_os = "linux")]
 fn parse_tab_inventory_lines(stdout: &[u8], strip_arch_suffix: bool) -> Vec<(String, String)> {
     String::from_utf8_lossy(stdout)
         .lines()
@@ -702,7 +670,7 @@ fn parse_tab_inventory_lines(stdout: &[u8], strip_arch_suffix: bool) -> Vec<(Str
         .collect()
 }
 
-#[allow(dead_code)]
+#[cfg(target_os = "linux")]
 fn parse_apk_inventory_lines(stdout: &[u8], package_names: &[String]) -> Vec<(String, String)> {
     let mut names = package_names.to_vec();
     names.sort_by(|a, b| b.len().cmp(&a.len()).then_with(|| a.cmp(b)));
@@ -762,7 +730,8 @@ mod tests {
         assert_eq!(normalize_package_token("Docker Desktop"), "docker-desktop");
     }
 
-    #[test]
+    #[cfg(target_os = "macos")]
+#[test]
     fn matches_manual_beta_app_to_versioned_request() {
         assert_eq!(
             matching_manual_app_name("raycast@beta", ["Raycast Beta.app"]),
@@ -775,7 +744,8 @@ mod tests {
         assert_eq!(matching_manual_app_name("cast", ["Raycast Beta.app"]), None);
     }
 
-    #[test]
+    #[cfg(target_os = "macos")]
+#[test]
     fn matches_cask_aliases() {
         let cask = Cask {
             token: "google-chrome".to_string(),
@@ -803,7 +773,8 @@ mod tests {
         assert_eq!(resolved.version.as_deref(), Some("1.0"));
     }
 
-    fn test_cask(token: &str, names: &[&str], homepage: &str, version: &str) -> Cask {
+    #[cfg(target_os = "macos")]
+fn test_cask(token: &str, names: &[&str], homepage: &str, version: &str) -> Cask {
         Cask {
             token: token.to_string(),
             full_token: token.to_string(),
@@ -817,7 +788,8 @@ mod tests {
         }
     }
 
-    #[test]
+    #[cfg(target_os = "macos")]
+#[test]
     fn prefers_exact_version_when_app_name_is_ambiguous() {
         let casks = vec![
             test_cask("example", &["Example"], "https://example.invalid/", "9.9.9"),
@@ -842,7 +814,8 @@ mod tests {
         assert_eq!(resolved.version.as_deref(), Some("1.2.3"));
     }
 
-    #[test]
+    #[cfg(target_os = "macos")]
+#[test]
     fn uses_bundle_identifier_to_break_ambiguous_app_name_tie() {
         let casks = vec![
             test_cask("example", &["Example"], "https://example.invalid/", "9.9.9"),
@@ -866,7 +839,8 @@ mod tests {
         assert_eq!(casks[resolved.cask_index].token, "vendor-example");
     }
 
-    #[test]
+    #[cfg(target_os = "macos")]
+#[test]
     fn does_not_guess_when_app_name_is_ambiguous() {
         let casks = vec![
             test_cask("example", &["Example"], "https://example.invalid/", "9.9.9"),
@@ -889,7 +863,8 @@ mod tests {
         assert_eq!(resolve_cask_match(&casks, &index, &app), None);
     }
 
-    #[test]
+    #[cfg(target_os = "macos")]
+#[test]
     fn combines_bundle_version_when_cask_uses_build_suffix() {
         assert_eq!(
             combine_bundle_version_for_cask("1.2.3", "456", "1.2.3,456"),


### PR DESCRIPTION
🎯 **What:** Replaced `#[allow(dead_code)]` directives on platform-specific functions in `src/discovery.rs` (like `discover_manually_installed_casks`, `discover_linux_system_packages`) and `src/adopt.rs` with appropriate conditional compilation attributes (`#[cfg(target_os = "...")]`). Replaced runtime conditional blocks (`if cfg!(target_os = "...")`) with `#[cfg(...)]` in `src/adopt.rs` to allow the functions to be successfully excluded at compile time without producing missing symbol errors. Cleaned up corresponding structs, imports, and tests.

💡 **Why:** `#[allow(dead_code)]` was used globally on functions that were only ever intended to run on specific platforms, while relying on dummy implementation blocks for unsupported OSs to bypass `if cfg!(...)` runtime blocks in calling code. This caused clutter and did not reflect true compile-time platform requirements. Replacing this with proper `#[cfg(...)]` tags cleanly delineates which chunks of code belong to which platforms and allows the compiler to fully drop unused code.

✅ **Verification:** Verified by compiling the repository and successfully running the test suite (`cargo check`, `cargo test`) on Linux, confirming that test assertions related to macOS logic are properly gated out and no missing symbols or `dead_code` warnings are thrown across modules.

✨ **Result:** A cleaner implementation of platform-specific code. Platform dependencies are explicitly handled at the compilation stage with `cfg`, and unnecessary placeholder code and compiler directives (`#[allow(dead_code)]`) have been removed, vastly improving readability and clarity in `discovery.rs`.

---
*PR created automatically by Jules for task [10305556688532590432](https://jules.google.com/task/10305556688532590432) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with no intended behavior change; risk is mainly a mis-applied cfg breaking a platform build, which cargo check/test on Linux is meant to catch.
> 
> **Overview**
> Platform-specific discovery and adoption logic is now **compile-time gated** with `#[cfg(target_os = "macos")]` / `#[cfg(target_os = "linux")]` instead of shipping stub bodies and silencing `dead_code` warnings.
> 
> In **`discovery.rs`**, macOS-only cask/`/Applications` scanning and Linux-only dpkg/rpm/pacman/apk inventory helpers are each defined only on their OS; nested `#[cfg(not(...))]` empty returns inside those entry points are removed. Imports and helpers follow the same split; `normalize_package_token` stays available on both macOS and Linux via `#[cfg(any(...))]`.
> 
> In **`adopt.rs`**, discovery imports and macOS-only pieces (`merge_discovered_casks`, manual-app uninstall hints) are cfg-gated, and **`sync_installed_state`** uses `#[cfg]` blocks instead of runtime `if cfg!(target_os = "...")` for Linux formula discovery and macOS cask merge. Related unit tests are gated to macOS where they exercise cask merge behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46e4a06ed721608d8070d34ba2b4212ad77b1404. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->