### PR TITLE
🔒 Fix argument injection vulnerability in pkgutil and installer in Cask PKG installation

### DIFF
--- a/src/cask.rs
+++ b/src/cask.rs
@@ -1463,6 +1463,7 @@ impl CaskInstaller {
             // Verify the PKG file signature before executing it with elevated privileges.
             let verify_output = tokio::process::Command::new("pkgutil")
                 .arg("--check-signature")
+                .arg("--")
                 .arg(&source)
                 .output()
                 .await?;
@@ -1502,10 +1503,16 @@ impl CaskInstaller {
             .await
             .map_err(|e| WaxError::InstallError(e.to_string()))??;
 
+            let safe_source = if source.is_absolute() {
+                source.clone()
+            } else {
+                std::path::Path::new(".").join(&source)
+            };
+
             let install_output = tokio::process::Command::new("sudo")
                 .arg("installer")
                 .arg("-pkg")
-                .arg(&source)
+                .arg(&safe_source)
                 .arg("-target")
                 .arg("/")
                 .output()


### PR DESCRIPTION
🎯 **What:** 
Fixes an argument injection vulnerability in the macOS Cask PKG installation pipeline where a user-controlled `source` path was passed unsafely to the `pkgutil` and `installer` commands.

⚠️ **Risk:** 
If an attacker controls the artifact download URL or path in a cask definition, they could craft a path starting with a hyphen (e.g., `-evil`) that the command-line tools would interpret as an unintended option. This could lead to arbitrary option injection, allowing an attacker to bypass signature checks (`pkgutil`) or manipulate the installation process (`installer`) when executing commands with elevated privileges.

🛡️ **Solution:** 
- Added the standard POSIX `--` argument separator before the `source` argument in the `pkgutil` invocation to explicitly terminate option parsing.
- For the `sudo installer -pkg` command (which doesn't conventionally support `--`), added a `safe_source` variable that evaluates whether the path is absolute. If it is relative and starts with a `-`, it safely prefixes the path with `./`, ensuring the tool correctly treats it as a file path rather than an option.

---
*PR created automatically by Jules for task [17282003823809303446](https://jules.google.com/task/17282003823809303446) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches privileged PKG installation and signature verification; incorrect path handling could break installs or weaken checks, though the change is narrowly defensive.
> 
> **Overview**
> **Hardens macOS Cask PKG installs** so user-influenced package paths cannot be parsed as extra flags when `pkgutil` and `installer` run (including under `sudo`).
> 
> `pkgutil --check-signature` now passes **`--`** before the package path so signature verification cannot be tricked by hyphen-prefixed paths. For **`sudo installer -pkg`**, the path passed to `-pkg` is normalized via **`safe_source`**: absolute paths are unchanged; non-absolute paths are joined under **`./`** so a relative name that starts with `-` is treated as a file, not an installer option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5456deba9120136f2049378e7e7e5b53289677c6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->