### PR TITLE
🔒 Fix tar command injection vulnerability during archive extraction

### DIFF
--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -448,7 +448,8 @@ async fn stage_binary_release_download(
         tokio::fs::write(&archive_path, bytes).await?;
 
         let tar_output = tokio::process::Command::new("tar")
-            .arg("xf")
+            .arg("-x")
+            .arg("-f")
             .arg(&archive_path)
             .arg("-C")
             .arg(&extract_dir)


### PR DESCRIPTION
🎯 **What:**
Fixed a potential command injection vulnerability in `src/commands/install.rs` where an unvalidated source tarball path (`archive_path`) could be interpreted as a command-line option by `tar`.

⚠️ **Risk:**
If a malicious user or compromised remote source provides a tarball download URL that results in a filename starting with a hyphen (e.g., `-test.tar.gz`), the `tar` command would interpret the filename as a flag/option rather than a file to extract. This could lead to unexpected behavior, command injection, or arbitrary command execution during the package installation phase.

🛡️ **Solution:**
Modified the `tokio::process::Command` invocation for `tar`. Replaced the clustered `.arg("xf")` with explicit, separated `.arg("-x")` and `.arg("-f")` arguments. When `-f` is provided as an isolated argument, the immediately following argument (`&archive_path`) is unambiguously consumed as the filename by the `tar` argument parser, effectively preventing the path from being parsed as an option even if it starts with a `-`. This is the recommended POSIX way to handle untrusted filenames passed to `tar`.

✅ **Verification:**
Ran the full test suite (`cargo test`) which completed successfully, ensuring no existing functionality is broken. Manually validated via bash tests that `tar -x -f -filename.tar` correctly processes filenames starting with hyphens without interpreting them as options.

---
*PR created automatically by Jules for task [6188832662635967537](https://jules.google.com/task/6188832662635967537) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line behavioral hardening in install-time `tar` extraction with no broader install flow changes; reduces command-line parsing risk during package install.
> 
> **Overview**
> Hardens **binary-release archive extraction** in `stage_binary_release_download` so untrusted local archive paths cannot be parsed as `tar` options.
> 
> The `tar` invocation no longer uses a single `xf` argument; it passes **`-x` and `-f` separately**, with the archive path immediately after `-f`. That keeps filenames derived from download URLs (via `binary_release_download_filename`) treated as the archive file even when they start with `-`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af204bbbc227be339a112998f10ef89d1baca502. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->