### PR TITLE
Test coverage + fixes for catalog matching and qualified package names

### DIFF
--- a/src/catalog_match.rs
+++ b/src/catalog_match.rs
@@ -1,7 +1,10 @@
 //! Shared catalogue search scoring (Homebrew names, Scoop/winget/choco ids).
 
 pub fn catalog_match_score(name: &str, query: &str) -> Option<i32> {
-    let q = query.to_lowercase();
+    let q = query.trim().to_lowercase();
+    if q.is_empty() {
+        return None;
+    }
     let n = name.to_lowercase();
     if n == q {
         return Some(1000);
@@ -30,7 +33,10 @@ pub fn catalog_match_score(name: &str, query: &str) -> Option<i32> {
 pub fn match_score(name: &str, desc: Option<&str>, query: &str) -> Option<i32> {
     let mut best = catalog_match_score(name, query);
     if let Some(desc) = desc {
-        let q = query.to_lowercase();
+        let q = query.trim().to_lowercase();
+        if q.is_empty() {
+            return best;
+        }
         let desc_lower = desc.to_lowercase();
         if desc_lower.contains(&q) {
             best = Some(best.map_or(300, |s| s.max(300)));
@@ -54,6 +60,87 @@ mod tests {
         assert_eq!(
             catalog_match_score("agent-browser", "agent-browser"),
             Some(1000)
+        );
+    }
+
+    #[test]
+    fn score_ladder_is_ordered_by_match_quality() {
+        assert_eq!(catalog_match_score("ripgrep", "ripgrep"), Some(1000));
+        assert_eq!(catalog_match_score("ripgrep-all", "ripgrep"), Some(900));
+        assert_eq!(catalog_match_score("go-ripgrep", "ripgrep"), Some(850));
+        assert_eq!(catalog_match_score("nothing", "ripgrep"), None);
+    }
+
+    #[test]
+    fn substring_tier_absorbs_word_tiers() {
+        // Any whole-word or word-prefix hit is also a substring hit, so the 800/700
+        // tiers below `contains` are never reached.
+        assert_eq!(catalog_match_score("go ripgrep tool", "ripgrep"), Some(850));
+        assert_eq!(catalog_match_score("go ripgrepall", "ripgrep"), Some(850));
+    }
+
+    #[test]
+    fn scoring_is_case_insensitive_both_ways() {
+        assert_eq!(
+            catalog_match_score("JesseDuffield.lazygit", "jesseduffield.lazygit"),
+            Some(1000)
+        );
+        assert_eq!(
+            catalog_match_score("microsoft.windowsterminal", "Microsoft.WindowsTerminal"),
+            Some(1000)
+        );
+    }
+
+    #[test]
+    fn dotted_winget_ids_match_on_segment() {
+        assert_eq!(
+            catalog_match_score("JesseDuffield.lazygit", "lazygit"),
+            Some(850)
+        );
+        assert_eq!(
+            catalog_match_score("Microsoft.VisualStudioCode", "visualstudio"),
+            Some(850)
+        );
+    }
+
+    #[test]
+    fn empty_query_matches_nothing() {
+        assert_eq!(catalog_match_score("ripgrep", ""), None);
+        assert_eq!(catalog_match_score("ripgrep", "   "), None);
+        assert_eq!(catalog_match_score("", ""), None);
+    }
+
+    #[test]
+    fn query_is_trimmed_before_matching() {
+        assert_eq!(catalog_match_score("ripgrep", "  ripgrep "), Some(1000));
+    }
+
+    #[test]
+    #[cfg(not(target_os = "windows"))]
+    fn empty_query_does_not_match_via_description() {
+        assert_eq!(match_score("ripgrep", Some("search tool"), ""), None);
+        assert_eq!(match_score("ripgrep", Some("search tool"), "  "), None);
+    }
+
+    #[test]
+    #[cfg(not(target_os = "windows"))]
+    fn name_match_outranks_description_match() {
+        assert_eq!(
+            match_score("ripgrep", Some("ripgrep is a search tool"), "ripgrep"),
+            Some(1000)
+        );
+    }
+
+    #[test]
+    #[cfg(not(target_os = "windows"))]
+    fn hyphenated_query_falls_back_to_spaced_description() {
+        assert_eq!(
+            match_score("rg", Some("recursive search tool"), "recursive-search"),
+            Some(250)
+        );
+        assert_eq!(
+            match_score("rg", Some("recursive search"), "no-match"),
+            None
         );
     }
 

--- a/src/chocolatey.rs
+++ b/src/chocolatey.rs
@@ -2,16 +2,24 @@
 //! Only packages that ship portable `.exe` files under `tools/` without requiring
 //! `chocolateyinstall.ps1` downloads are supported for wax-managed install.
 
-use crate::bottle::BottleDownloader;
 use crate::error::{Result, WaxError};
-use crate::package_spec::Ecosystem;
-use crate::scoop;
-use crate::windows_state::{self, WindowsPackageManifest};
-use indicatif::{ProgressBar, ProgressStyle};
 use regex::Regex;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
+
+#[cfg(target_os = "windows")]
+use crate::bottle::BottleDownloader;
+#[cfg(target_os = "windows")]
+use crate::package_spec::Ecosystem;
+#[cfg(target_os = "windows")]
+use crate::scoop;
+#[cfg(target_os = "windows")]
+use crate::windows_state::{self, WindowsPackageManifest};
+#[cfg(target_os = "windows")]
+use indicatif::{ProgressBar, ProgressStyle};
+#[cfg(target_os = "windows")]
 use tempfile::TempDir;
+#[cfg(target_os = "windows")]
 use tracing::debug;
 
 static SEARCH_RE: OnceLock<Regex> = OnceLock::new();
@@ -60,13 +68,16 @@ pub async fn package_exists(id: &str) -> bool {
 }
 
 /// Install latest `.nupkg` if it contains at least one `tools/*.exe` and no mandatory script-only layout.
-pub async fn install_portable_tools(id: &str) -> Result<()> {
-    if !cfg!(target_os = "windows") {
-        return Err(WaxError::PlatformNotSupported(
-            "Chocolatey-backed portable install is only supported on Windows".into(),
-        ));
-    }
+#[cfg(not(target_os = "windows"))]
+pub async fn install_portable_tools(_id: &str) -> Result<()> {
+    Err(WaxError::PlatformNotSupported(
+        "Chocolatey-backed portable install is only supported on Windows".into(),
+    ))
+}
 
+/// Install latest `.nupkg` if it contains at least one `tools/*.exe` and no mandatory script-only layout.
+#[cfg(target_os = "windows")]
+pub async fn install_portable_tools(id: &str) -> Result<()> {
     let nupkg_url = format!("https://community.chocolatey.org/api/v2/package/{}", id);
     debug!("Chocolatey nupkg {}", nupkg_url);
 
@@ -86,6 +97,7 @@ pub async fn install_portable_tools(id: &str) -> Result<()> {
     Ok(())
 }
 
+#[cfg(target_os = "windows")]
 fn stage_and_link_tools(
     id: &str,
     nupkg_url: String,
@@ -143,6 +155,7 @@ fn stage_and_link_tools(
     Ok(())
 }
 
+#[cfg(target_os = "windows")]
 async fn download_nupkg(id: &str, nupkg_url: &str, nupkg_path: &Path) -> Result<()> {
     let dl = BottleDownloader::new();
     let size = dl.probe_size(nupkg_url).await;
@@ -208,11 +221,125 @@ fn collect_exe_files(dir: &Path, out: &mut Vec<PathBuf>, depth: u32, max_depth: 
                 .map(|s| s.to_string_lossy().to_string())
                 .unwrap_or_default();
             let nl = name.to_lowercase();
-            if nl.contains("uninstall") || nl.contains("chocolatey") {
+            if nl.contains("uninstall") || nl.contains("chocolatey") || nl.starts_with("unins") {
                 continue;
             }
             out.push(p);
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn touch(path: &Path) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, b"").unwrap();
+    }
+
+    #[test]
+    fn missing_tools_dir_is_an_install_error() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let err = get_tools_and_exes(tmp.path()).unwrap_err();
+        assert!(
+            err.to_string().contains("no tools/ directory"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn script_only_package_reports_the_scoop_winget_hint() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        touch(&tmp.path().join("tools").join("chocolateyinstall.ps1"));
+        let err = get_tools_and_exes(tmp.path()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("chocolateyinstall.ps1"), "unexpected: {msg}");
+        assert!(msg.contains("scoop/"), "unexpected: {msg}");
+    }
+
+    #[test]
+    fn tools_dir_without_exes_reports_no_portable_exe() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        touch(&tmp.path().join("tools").join("readme.txt"));
+        let err = get_tools_and_exes(tmp.path()).unwrap_err();
+        assert!(
+            err.to_string().contains("No suitable portable .exe"),
+            "unexpected: {err}"
+        );
+    }
+
+    #[test]
+    fn portable_exes_are_collected_recursively() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let tools = tmp.path().join("tools");
+        touch(&tools.join("app.exe"));
+        touch(&tools.join("nested").join("helper.EXE"));
+        let (dir, mut exes) = get_tools_and_exes(tmp.path()).unwrap();
+        assert_eq!(dir, tools);
+        exes.sort();
+        let names: Vec<String> = exes
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(names, vec!["app.exe", "helper.EXE"]);
+    }
+
+    #[test]
+    fn uninstaller_and_chocolatey_shims_are_skipped() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let tools = tmp.path().join("tools");
+        touch(&tools.join("app.exe"));
+        touch(&tools.join("Uninstall.exe"));
+        touch(&tools.join("unins000.exe"));
+        touch(&tools.join("chocolateyProxy.exe"));
+        let (_, mut exes) = get_tools_and_exes(tmp.path()).unwrap();
+        exes.sort();
+        let names: Vec<String> = exes
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(names, vec!["app.exe"]);
+    }
+
+    #[test]
+    fn recursion_stops_past_the_depth_limit() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let deep = tmp.path().join("a").join("b").join("c");
+        touch(&deep.join("too-deep.exe"));
+        let mut out = Vec::new();
+        collect_exe_files(tmp.path(), &mut out, 0, 1).unwrap();
+        assert!(out.is_empty());
+
+        let mut out = Vec::new();
+        collect_exe_files(tmp.path(), &mut out, 0, 4).unwrap();
+        assert_eq!(out.len(), 1);
+    }
+
+    #[test]
+    fn missing_directory_surfaces_an_io_error() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut out = Vec::new();
+        assert!(collect_exe_files(&tmp.path().join("nope"), &mut out, 0, 4).is_err());
+    }
+
+    #[tokio::test]
+    async fn blank_query_never_hits_the_network() {
+        assert!(search_package_ids("", 10).await.unwrap().is_empty());
+        assert!(search_package_ids("   ", 10).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    #[cfg(not(target_os = "windows"))]
+    async fn portable_install_is_windows_only() {
+        let err = install_portable_tools("git").await.unwrap_err();
+        assert!(
+            matches!(err, WaxError::PlatformNotSupported(_)),
+            "unexpected error: {err}"
+        );
+    }
 }

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -86,6 +86,14 @@ struct UnixSearchResults<'a> {
 }
 
 #[cfg(not(target_os = "windows"))]
+fn best_of(a: Option<i32>, b: Option<i32>) -> Option<i32> {
+    match (a, b) {
+        (Some(a), Some(b)) => Some(a.max(b)),
+        (a, b) => a.or(b),
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
 fn find_unix_matches<'a>(
     formulae: &'a [crate::api::Formula],
     casks: &'a [crate::api::Cask],
@@ -115,7 +123,7 @@ fn find_unix_matches<'a>(
             let name_score = crate::catalog_match::match_score(&f.name, f.desc.as_deref(), query);
             let full_name_score =
                 crate::catalog_match::match_score(&f.full_name, f.desc.as_deref(), query);
-            name_score.or(full_name_score).map(|score| (*f, score))
+            best_of(name_score, full_name_score).map(|score| (*f, score))
         })
         .collect();
 
@@ -128,7 +136,7 @@ fn find_unix_matches<'a>(
                 .iter()
                 .filter_map(|n| crate::catalog_match::match_score(n, c.desc.as_deref(), query))
                 .max();
-            token_score.or(name_score).map(|score| (c, score))
+            best_of(token_score, name_score).map(|score| (c, score))
         })
         .collect();
 
@@ -220,7 +228,27 @@ fn print_unix_results(
 }
 
 #[cfg(not(target_os = "windows"))]
-async fn search_unix(cache: &Cache, query: &str) -> Result<()> {
+async fn search_unix(cache: &Cache, raw_query: &str) -> Result<()> {
+    let (eco_filter, parsed) = crate::package_spec::parse_search_query(raw_query);
+    let query = parsed.trim();
+    if query.is_empty() {
+        println!("empty search query");
+        return Ok(());
+    }
+    if let Some(eco) = eco_filter {
+        if eco != crate::package_spec::Ecosystem::Brew {
+            println!(
+                "{}",
+                style(format!(
+                    "{}/ packages are only available on Windows; searching Homebrew instead is not possible for this prefix",
+                    eco.label()
+                ))
+                .dim()
+            );
+            return Ok(());
+        }
+    }
+
     cache.ensure_fresh().await?;
 
     let formulae = cache.load_all_formulae().await?;
@@ -281,5 +309,129 @@ fn print_cask(cask: &crate::api::Cask, is_installed: bool) {
     );
     if !desc.is_empty() {
         println!("  {}", desc);
+    }
+}
+
+#[cfg(all(test, not(target_os = "windows")))]
+mod tests {
+    use super::*;
+    use crate::api::{Cask, Formula};
+
+    fn formula(name: &str, full_name: &str, desc: Option<&str>) -> Formula {
+        serde_json::from_value(serde_json::json!({
+            "name": name,
+            "full_name": full_name,
+            "desc": desc,
+            "homepage": "https://example.invalid",
+            "versions": {"stable": "1.0.0", "bottle": true},
+            "installed": null,
+            "dependencies": null,
+            "build_dependencies": null,
+            "bottle": null,
+            "keg_only": null,
+            "keg_only_reason": null,
+            "deprecation_reason": null,
+            "disable_reason": null,
+        }))
+        .expect("formula fixture")
+    }
+
+    fn cask(token: &str, names: &[&str], desc: Option<&str>) -> Cask {
+        Cask {
+            token: token.to_string(),
+            full_token: format!("homebrew/cask/{token}"),
+            name: names.iter().map(|n| n.to_string()).collect(),
+            desc: desc.map(|d| d.to_string()),
+            homepage: "https://example.invalid".to_string(),
+            version: "1.0.0".to_string(),
+            deprecated: false,
+            disabled: false,
+            rb_path: None,
+        }
+    }
+
+    #[test]
+    fn best_of_takes_the_higher_of_two_scores() {
+        assert_eq!(best_of(Some(850), Some(1000)), Some(1000));
+        assert_eq!(best_of(Some(1000), Some(850)), Some(1000));
+        assert_eq!(best_of(None, Some(700)), Some(700));
+        assert_eq!(best_of(Some(700), None), Some(700));
+        assert_eq!(best_of(None, None), None);
+    }
+
+    #[test]
+    fn cask_display_name_can_outrank_the_token() {
+        // "anaconda" merely contains "conda" (850) while the display name "conda"
+        // is an exact hit (1000); the exact hit must win the ordering.
+        let casks = vec![
+            cask("anaconda", &["Anaconda"], None),
+            cask("zzz-conda-tool", &["conda"], None),
+        ];
+        let results = find_unix_matches(&[], &casks, "conda");
+        assert_eq!(results.cask_matches.len(), 2);
+        assert_eq!(results.cask_matches[0].token, "zzz-conda-tool");
+    }
+
+    #[test]
+    fn exact_formula_name_sorts_above_substring_match() {
+        let formulae = vec![
+            formula("aaa-ripgrep-all", "aaa-ripgrep-all", None),
+            formula("ripgrep", "ripgrep", None),
+        ];
+        let results = find_unix_matches(&formulae, &[], "ripgrep");
+        assert_eq!(results.formula_matches[0].name, "ripgrep");
+    }
+
+    #[test]
+    fn tap_formulae_are_separated_from_core_formulae() {
+        let formulae = vec![
+            formula("ripgrep", "ripgrep", None),
+            formula("ripgrep", "plyght/tap/ripgrep", None),
+        ];
+        let results = find_unix_matches(&formulae, &[], "ripgrep");
+        assert_eq!(results.formula_matches.len(), 1);
+        assert_eq!(results.formula_matches[0].full_name, "ripgrep");
+        assert_eq!(results.tap_matches.len(), 1);
+        assert_eq!(results.tap_matches[0].full_name, "plyght/tap/ripgrep");
+    }
+
+    #[test]
+    fn tap_formula_matches_on_full_name_only() {
+        let formulae = vec![formula("wax", "plyght/tap/wax", None)];
+        let results = find_unix_matches(&formulae, &[], "plyght/tap");
+        assert_eq!(results.tap_matches.len(), 1);
+    }
+
+    #[test]
+    fn empty_query_matches_nothing_at_all() {
+        let formulae = vec![formula("ripgrep", "ripgrep", Some("search tool"))];
+        let casks = vec![cask("firefox", &["Firefox"], Some("browser"))];
+        let results = find_unix_matches(&formulae, &casks, "");
+        assert!(results.formula_matches.is_empty());
+        assert!(results.cask_matches.is_empty());
+        assert!(results.tap_matches.is_empty());
+    }
+
+    #[test]
+    fn description_only_matches_are_ranked_below_name_matches() {
+        let formulae = vec![
+            formula("unrelated", "unrelated", Some("a ripgrep clone")),
+            formula("ripgrep", "ripgrep", None),
+        ];
+        let results = find_unix_matches(&formulae, &[], "ripgrep");
+        assert_eq!(results.formula_matches.len(), 2);
+        assert_eq!(results.formula_matches[0].name, "ripgrep");
+    }
+
+    #[test]
+    fn formula_results_are_capped_at_twenty() {
+        let formulae: Vec<_> = (0..30)
+            .map(|i| {
+                let name = format!("ripgrep-{i:02}");
+                formula(&name, &name, None)
+            })
+            .collect();
+        let results = find_unix_matches(&formulae, &[], "ripgrep");
+        assert_eq!(results.formula_matches.len(), 20);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,13 +23,12 @@ mod version;
 mod xcode;
 
 // Windows package manager support (scoop, winget, chocolatey)
-#[cfg(target_os = "windows")]
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 mod chocolatey;
 #[cfg(target_os = "windows")]
 mod ecosystem_install;
-#[cfg(target_os = "windows")]
 mod package_spec;
-#[cfg(target_os = "windows")]
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 mod remote_search;
 #[cfg(target_os = "windows")]
 mod scoop;

--- a/src/package_spec.rs
+++ b/src/package_spec.rs
@@ -147,6 +147,71 @@ mod tests {
     }
 
     #[test]
+    fn uppercase_prefixes_are_recognised() {
+        for raw in ["SCOOP/foo", "Choco/foo", "WINGET/foo", "HomeBrew/foo"] {
+            assert!(
+                parse_package_spec(raw).force.is_some(),
+                "prefix not matched: {raw}"
+            );
+            assert_eq!(parse_package_spec(raw).name, "foo");
+        }
+    }
+
+    #[test]
+    fn name_case_is_preserved_for_winget_ids() {
+        let spec = parse_package_spec("winget/JesseDuffield.lazygit");
+        assert_eq!(spec.force, Some(Ecosystem::Winget));
+        assert_eq!(spec.name, "JesseDuffield.lazygit");
+    }
+
+    #[test]
+    fn chocolatey_prefix_wins_over_choco_prefix() {
+        let spec = parse_package_spec("chocolatey/git");
+        assert_eq!(spec.force, Some(Ecosystem::Chocolatey));
+        assert_eq!(spec.name, "git");
+    }
+
+    #[test]
+    fn extra_slashes_stay_in_the_name() {
+        let spec = parse_package_spec("scoop/extras/foo");
+        assert_eq!(spec.force, Some(Ecosystem::Scoop));
+        assert_eq!(spec.name, "extras/foo");
+    }
+
+    #[test]
+    fn homebrew_tap_names_are_not_treated_as_prefixes() {
+        let spec = parse_package_spec("homebrew/cask/firefox");
+        assert_eq!(spec.force, Some(Ecosystem::Brew));
+        assert_eq!(spec.name, "cask/firefox");
+
+        let spec = parse_package_spec("plyght/tap/wax");
+        assert_eq!(spec.force, None);
+        assert_eq!(spec.name, "plyght/tap/wax");
+    }
+
+    #[test]
+    fn label_round_trips_through_the_parser() {
+        for eco in [
+            Ecosystem::Brew,
+            Ecosystem::Scoop,
+            Ecosystem::Winget,
+            Ecosystem::Chocolatey,
+        ] {
+            let raw = format!("{}/pkg", eco.label());
+            let spec = parse_package_spec(&raw);
+            assert_eq!(spec.force, Some(eco), "round trip failed for {raw}");
+            assert_eq!(spec.name, "pkg");
+        }
+    }
+
+    #[test]
+    fn parse_search_query_leaves_plain_queries_untouched() {
+        let (f, q) = parse_search_query("ripgrep");
+        assert_eq!(f, None);
+        assert_eq!(q, "ripgrep");
+    }
+
+    #[test]
     fn speed_rank_orders_fastest_first() {
         assert!(Ecosystem::Brew.speed_rank() < Ecosystem::Scoop.speed_rank());
         assert!(Ecosystem::Scoop.speed_rank() < Ecosystem::Winget.speed_rank());

--- a/src/remote_search.rs
+++ b/src/remote_search.rs
@@ -601,11 +601,103 @@ mod tests {
     }
 
     #[test]
+    fn winget_manifest_path_handles_multi_segment_ids() {
+        let path = "manifests/m/Microsoft/VisualStudio/2022/Community/17.8.3/Microsoft.VisualStudio.2022.Community.installer.yaml";
+        assert_eq!(
+            package_id_from_winget_manifest_path(path).as_deref(),
+            Some("Microsoft.VisualStudio.2022.Community")
+        );
+    }
+
+    #[test]
+    fn winget_manifest_path_rejects_non_version_directory() {
+        let path = "manifests/j/JesseDuffield/lazygit/nightly/JesseDuffield.lazygit.installer.yaml";
+        assert_eq!(package_id_from_winget_manifest_path(path), None);
+    }
+
+    #[test]
+    fn winget_manifest_path_rejects_paths_without_manifests_root() {
+        assert_eq!(
+            package_id_from_winget_manifest_path("j/Jesse/lazygit/1.0/x.installer.yaml"),
+            None
+        );
+        assert_eq!(package_id_from_winget_manifest_path(""), None);
+        assert_eq!(package_id_from_winget_manifest_path("manifests"), None);
+    }
+
+    #[test]
+    fn winget_manifest_path_rejects_too_shallow_paths() {
+        assert_eq!(
+            package_id_from_winget_manifest_path("manifests/j/1.0/x.installer.yaml"),
+            None
+        );
+    }
+
+    #[test]
+    fn version_folder_detection_requires_leading_digit() {
+        assert!(looks_like_version_folder("1.2.3"));
+        assert!(looks_like_version_folder("2022"));
+        assert!(!looks_like_version_folder("v1.2.3"));
+        assert!(!looks_like_version_folder("latest"));
+        assert!(!looks_like_version_folder(""));
+    }
+
+    #[test]
+    fn dedupe_sorts_by_score_then_speed_then_id() {
+        let hits = vec![
+            hit(Ecosystem::Chocolatey, "b-low", 100),
+            hit(Ecosystem::Winget, "a-high", 900),
+            hit(Ecosystem::Scoop, "b-high", 900),
+        ];
+        let d = dedupe_remote_by_speed(hits);
+        let ids: Vec<&str> = d.iter().map(|h| h.id.as_str()).collect();
+        assert_eq!(ids, vec!["b-high", "a-high", "b-low"]);
+    }
+
+    #[test]
+    fn dedupe_keeps_the_first_seen_casing_of_an_id() {
+        let hits = vec![
+            hit(Ecosystem::Scoop, "RipGrep", 900),
+            hit(Ecosystem::Chocolatey, "ripgrep", 1000),
+        ];
+        let d = dedupe_remote_by_speed(hits);
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0].id, "RipGrep");
+    }
+
+    #[test]
+    fn dedupe_does_not_merge_distinct_ids() {
+        let hits = vec![
+            hit(Ecosystem::Scoop, "ripgrep", 1000),
+            hit(Ecosystem::Scoop, "ripgrep-all", 900),
+        ];
+        assert_eq!(dedupe_remote_by_speed(hits).len(), 2);
+    }
+
+    #[tokio::test]
+    async fn collect_remote_hits_short_circuits_on_blank_query() {
+        let cache = Cache::new().expect("cache");
+        for q in ["", "   "] {
+            let hits = collect_remote_hits(&cache, q, true, true, true)
+                .await
+                .expect("blank query must not error");
+            assert!(hits.is_empty());
+        }
+    }
+
+    #[test]
     fn scoop_tree_path_parses_bucket_json() {
         assert_eq!(
             scoop_name_from_tree_path("bucket/ripgrep.json").as_deref(),
             Some("ripgrep")
         );
         assert_eq!(scoop_name_from_tree_path("bucket/nested/foo.json"), None);
+    }
+
+    #[test]
+    fn scoop_tree_path_rejects_non_bucket_entries() {
+        assert_eq!(scoop_name_from_tree_path("README.md"), None);
+        assert_eq!(scoop_name_from_tree_path("bucket/ripgrep.yaml"), None);
+        assert_eq!(scoop_name_from_tree_path("scripts/bucket/foo.json"), None);
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -656,6 +656,39 @@ fn search_no_args_does_not_panic() {
 }
 
 #[test]
+#[cfg(not(windows))]
+fn search_windows_prefix_reports_platform_without_touching_the_network() {
+    for prefix in ["scoop", "winget", "choco", "chocolatey"] {
+        let home = tempfile::tempdir().unwrap();
+        let out = wax_with_home(home.path())
+            .arg("search")
+            .arg(format!("{prefix}/ripgrep"))
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(out.status.success(), "search {prefix}/ failed: {stdout}");
+        assert!(
+            stdout.contains("only available on Windows"),
+            "search {prefix}/ said: {stdout}"
+        );
+    }
+}
+
+#[test]
+#[cfg(not(windows))]
+fn search_empty_query_short_circuits() {
+    let home = tempfile::tempdir().unwrap();
+    let out = wax_with_home(home.path())
+        .arg("search")
+        .arg("   ")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(out.status.success(), "empty search failed: {stdout}");
+    assert!(stdout.contains("empty search query"), "said: {stdout}");
+}
+
+#[test]
 fn unknown_subcommand_exits_nonzero() {
     let out = wax()
         .arg("definitely-not-a-real-subcommand")


### PR DESCRIPTION
The scoop/winget/choco modules were gated behind `cfg(windows)`, so on macOS/Linux `cargo test` compiled **none** of the qualified-name parsing, catalog ranking, or Chocolatey logic. This un-gates the platform-independent parts (keeping the genuinely Windows-only install path gated) and adds tests that run everywhere.

## Bugs fixed

- **Unix search ignored qualified names.** `wax search brew/ripgrep` matched the literal string `brew/ripgrep` and found nothing; `scoop/x` silently searched Homebrew. `search_unix` now parses the prefix, searches Homebrew for `brew/`, and reports that Windows catalogues are unavailable for the others — before touching the network.
- **Empty query matched everything.** `starts_with("")` scored 900 against every entry, so `wax search ""` printed 20 arbitrary formulae and casks. `catalog_match_score` now returns `None` for blank queries and trims the query.
- **Ranking used `Option::or` instead of the higher score.** A cask whose display name exactly matched the query ranked below one that merely contained it (`conda` below `anaconda`). Same for tap `full_name`.
- **`unins000.exe` was treated as a package binary.** The Inno Setup uninstaller ships in many `.nupkg` `tools/` dirs; the filter only caught `uninstall`/`chocolatey`, so it got copied into the user's bin dir.

## Tests

+66 unit tests and +2 CLI tests covering the score ladder, case handling, dotted winget ids, prefix parsing (case, extra slashes, tap names, label round-trip), unix match ranking and caps, winget/scoop manifest path parsing, remote-hit dedupe ordering, and the Chocolatey `tools/` error paths. No Windows box or network required.

`cargo test`: 271 unit + 35 CLI passing. `cargo fmt --check` and `cargo clippy --all-targets` clean. `cargo check --target x86_64-pc-windows-gnu --all-targets` clean.

## Note, not changed

The 800/700 scoring tiers in `catalog_match_score` are unreachable — any whole-word or word-prefix hit is also a `contains` hit, which returns 850 first. Locked current behaviour in a test rather than reordering, since making word matches outrank mid-word substrings is a ranking decision for you to make.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible search ranking and prefix parsing across Unix and Windows catalog paths; Chocolatey install filtering affects which binaries land in the user bin dir on Windows.
> 
> **Overview**
> Fixes search and catalog matching bugs and expands cross-platform test coverage for parsing, ranking, and Chocolatey helpers.
> 
> **Search behavior:** Blank or whitespace-only queries no longer match every catalogue entry (`catalog_match_score` trims and returns `None`). On Unix, `wax search` now understands `brew/` vs `scoop/`/`winget/`/`choco/` prefixes: `brew/foo` searches Homebrew; Windows-only prefixes print a clear message without hitting the network. Cask and tap results use the **higher** of token/name or full_name scores instead of `Option::or`, so exact display-name hits rank above substring token matches.
> 
> **Qualified names:** `parse_package_spec` matches only the first path segment (case-insensitive ASCII), preserves winget ID casing, keeps extra slashes in the name (`scoop/extras/foo`), and avoids treating tap paths like `homebrew-core/git` as ecosystem prefixes.
> 
> **Chocolatey:** HTML search parsing is factored into `parse_search_ids` (lowercase IDs, version URLs collapsed, deduped limits). Portable `.exe` discovery skips Inno-style `unins*` uninstallers. Non-Windows builds compile shared logic and stub `install_portable_tools` so unit tests run on macOS/Linux.
> 
> **Build:** `chocolatey`, `package_spec`, and `remote_search` build on all targets; Windows-only install paths stay `cfg`-gated. Large additions are unit/CLI tests for scoring, prefix parsing, winget manifest paths, remote dedupe, and Chocolatey `tools/` error paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1aa43233412ab153a915a55f9ac813bf48821fd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->